### PR TITLE
Fix coordinate systems

### DIFF
--- a/src/scanning.jl
+++ b/src/scanning.jl
@@ -1,3 +1,77 @@
+# -*- encoding: utf-8 -*-
+#
+# MIT License
+#
+# Copyright (c) 2016 Maurizio Tomasi
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#
+# # TERMINOLOGY
+#
+# The code in this file tries to follow the conventions laid in
+# document LSPE-STRIP-SP-017 ("STRIP Telescope Coordinate Systems
+# Specification") as much as possible. As the reader might not be
+# aquainted with it, here is a short summary of the relevant
+# terminology:
+#
+# +-----+-----------------------------+------------------------------------------+
+# | SCS | Site Coordinate System      | Centered on the GPS station              |
+# +-----+-----------------------------+------------------------------------------+
+# | MCS | Mount Coordinate System     | Centered at the basis of the telescope   |
+# +-------+---------------------------+------------------------------------------+
+# | ACS | A zimuth Coordinate System  | Moveable, centered in the middle of      |
+# |     |                             | ground motor. Positive angles go from    |
+# |     |                             | North to *East* (beware!)                |
+# +-----+-----------------------------+------------------------------------------+
+# | ECS | Elevation Coordinate System | Moveable, the Y axis is aligned with     |
+# |     |                             | the motor axis                           |
+# +-----+-----------------------------+------------------------------------------+
+# | BCS | Boresight Coordinate System | It should have been moveable, but the    |
+# |     |                             | current design does not allow it (alas!) |
+# +-----+-----------------------------+------------------------------------------+
+# | RDP | Reference Detector Plane    | Centered in the focus of the telescope.  |
+# |     |                             | All the beam vectors are specified in    |
+# |     |                             | this frame.                              |
+# +-----+-----------------------------+------------------------------------------+
+#
+# We always use a right-handed coordinate system:
+#
+#                 ^ Z axis (aligned with "up" direction, e.g., Zenith)
+#                 |
+#                 |
+#                 |
+#                 |
+#                 |
+#                 |
+#                 |
+#                 |
+#                 |
+#          Origin O----------------> Y axis
+#                /
+#               /
+#              /
+#             /
+#            /
+#           v  X axis (aligned with North, when applicable)
+#
+
 import Quaternions
 import Healpix
 import StaticArrays
@@ -88,11 +162,11 @@ end
 """
 function telescopetoground(wheelanglesfn, time_s)
     (wheel1ang, wheel2ang, wheel3ang) = wheelanglesfn(time_s)
-    
+
     qwheel1 = qrotation_z(wheel1ang)
     qwheel2 = qrotation_y(wheel2ang)
     qwheel3 = qrotation_z(-wheel3ang)
-    
+
     qwheel3 * (qwheel2 * qwheel1)
 end
 
@@ -113,7 +187,7 @@ The keyword `day_duration_s` specifies the length of a day in seconds.
 function groundtoearth(groundq, time_s, latitude_deg; day_duration_s=86400.0)
     locq = qrotation_y(deg2rad(90 - latitude_deg))
     earthq = qrotation_z(2π * time_s / day_duration_s)
-    
+
     earthq * (locq * groundq)
 end
 
@@ -121,18 +195,18 @@ end
 """
     vector2equatorial(dir, jd, latitude_deg, longitude_deg, height_m)
 
-Transform the Healpix coordinates of a vector into equatorial coordinates. 
-The parameter `vector` is 3D vector, `jd` is the julian date. The 
-paramters `latitude_deg`, `longitude_deg` and `height_m` should contain the 
+Transform the Healpix coordinates of a vector into equatorial coordinates.
+The parameter `vector` is 3D vector, `jd` is the julian date. The
+paramters `latitude_deg`, `longitude_deg` and `height_m` should contain the
 latitude (in degrees, N is positive), the longitude (in degrees, counterclockwise
-is positive) and the height (in meters) of the location where the observation is 
-made. 
+is positive) and the height (in meters) of the location where the observation is
+made.
 """
 function vector2equatorial(vector, jd, latitude_deg, longitude_deg, height_m)
     (θ, ϕ) = Healpix.vec2ang(vector...)
-    alt_rad = π/2 - θ 
+    alt_rad = π/2 - θ
     az_rad = 2π - ϕ
-    
+
     ra_deg, dec_deg, _ = AstroLib.hor2eq(rad2deg(alt_rad),
                                          rad2deg(az_rad),
                                          jd,
@@ -158,7 +232,7 @@ function polarizationangle(northdir, poldir)
     cosψ = clamp(dot(northdir, poldir), -1, 1)
     crosspr = northdir × poldir
     sinψ = clamp(sqrt(dot(crosspr, crosspr)), -1, 1)
-    ψ = atan(sinψ, cosψ) 
+    ψ = atan(sinψ, cosψ)
     ψ
 end
 
@@ -186,7 +260,7 @@ function quat_to_angles(boreaxis, polaxis, quat)
     rotmatr = Quaternions.rotationmatrix(quat)
     boresight = rotmatr * boreaxis
     poldir = rotmatr * polaxis
-            
+
     (θ, ϕ) = Healpix.vec2ang(boresight...)
 
     northdir = get_northdir(θ, ϕ)
@@ -197,6 +271,7 @@ end
 function genpointings(wheelanglesfn,
                       dir,
                       timerange_s;
+                      polaxis=Float64[1.0, 0.0, 0.0],
                       latitude_deg=0.0,
                       ground=false)
 
@@ -208,22 +283,21 @@ function genpointings(wheelanglesfn,
         ψ = Array{Float64}(undef, length(timerange_s))
     end
 
-    zaxis = [1; 0; 0] #should be different for each horn...
     for (idx, time_s) = enumerate(timerange_s)
-        
+
         # This converts the RDP into the MCS (ground reference frame)
         groundq = telescopetoground(wheelanglesfn, time_s)
         # This converts the MCS into the celestial reference frame
         quat = groundtoearth(groundq, time_s, latitude_deg)
 
-        θ, ϕ, curψ = quat_to_angles(dir, zaxis, quat)
+        θ, ϕ, curψ = quat_to_angles(dir, polaxis, quat)
 
-        (dirs[idx, 1], dirs[idx, 2]) = (θ, ϕ) 
+        (dirs[idx, 1], dirs[idx, 2]) = (θ, ϕ)
         northdir = get_northdir(θ, ϕ)
-        
+
         if ground
             # Re-run the transformation algorithm using the ground quaternion
-            θ_ground, ϕ_ground, ψ_ground = quat_to_angles(dir, zaxis, groundq)
+            θ_ground, ϕ_ground, ψ_ground = quat_to_angles(dir, polaxis, groundq)
 
             (dirs[idx, 1], dirs[idx, 2], dirs[idx, 3], dirs[idx, 4]) = (θ, ϕ, θ_ground, ϕ_ground)
             (ψ[idx, 1], ψ[idx, 2]) = (curψ, ψ_ground)
@@ -232,7 +306,7 @@ function genpointings(wheelanglesfn,
             ψ[idx] = curψ
         end
     end
-    
+
     (dirs, ψ)
 end
 
@@ -241,10 +315,11 @@ function genpointings(wheelanglesfn,
                       dir,
                       timerange_s,
                       t_start;
+                      polaxis=Float64[1.0, 0.0, 0.0],
                       latitude_deg=0.0,
                       longitude_deg=0.0,
                       height_m=0)
-    
+
     skydirs = Array{Float64}(undef, length(timerange_s), 2)
     skyψ = Array{Float64}(undef, length(timerange_s))
 
@@ -253,7 +328,7 @@ function genpointings(wheelanglesfn,
 
         # This is in the ground reference frame
         groundq = telescopetoground(wheelanglesfn, time_s)
-        
+
         rotmatr = Quaternions.rotationmatrix(groundq)
         vector = rotmatr * dir
 
@@ -273,14 +348,14 @@ function genpointings(wheelanglesfn,
         #                                           latitude_deg,
         #                                           longitude_deg,
         #                                           height_m)
-        
+
         # skypoldir = StaticArrays.@SArray [cos(Decpol_rad) * cos(Rapol_rad),
         #                                   cos(Decpol_rad) * sin(Rapol_rad),
         #                                   sin(Decpol_rad)]
         # skynorthdir = StaticArrays.@SArray [-sin(Decpol_rad) * cos(Rapol_rad),
         #                                     -sin(Decpol_rad) * sin(Rapol_rad),
         #                                     cos(Decpol_rad)]
-        
+
         # skyψ[idx] = polarizationangle(skynorthdir, skypoldir)
         skyψ[idx] = 0.
     end
@@ -290,9 +365,11 @@ end
 
 
 @doc raw"""
-    genpointings(wheelanglesfn, dir, timerange_s; latitude_deg=0.0, 
-                 ground=false)
-    genpointings(wheelanglesfn, dir, timerange_s, t_start, t_stop; 
+    genpointings(wheelanglesfn, dir, timerange_s; 
+                 polaxis=Float64[1.0, 0.0, 0.0],
+                 latitude_deg=0.0, ground=false)
+    genpointings(wheelanglesfn, dir, timerange_s, t_start, t_stop;
+                 polaxis=Float64[1.0, 0.0, 0.0],
                  latitude_deg=0.0, longitude_deg=0.0, height_m=0.0)
 
 Generate a set of pointings for a STRIP detector. The parameter
@@ -309,7 +386,7 @@ the three motors:
 3. The ground motor (rotation around the ``z`` axis, **clockwise**:
    N→E→S→W)
 
-The meaning of the parameters is the following:
+The meaning of the parameters/keywords is the following:
 
 - `dir` specifies the pointing direction of the mean (the boresight is
   [0, 0, 1]). It must be normalized.
@@ -325,6 +402,7 @@ is made (in degrees, North is positive).
   coordinates (columns 1 and 2) and in ground coordinates (columns 3
   and 4). If false, only the Equatorial coordinates are computed.
 
+- `polaxis` is the polarization axis; it must be normalized
 
 # Return values
 
@@ -359,9 +437,9 @@ notation.
 import Dates
 
 dirs, psi = genpointings(time_s -> (0, deg2rad(20), timetorotang(time_s, 1)),
-                         [0, 0, 1], 
-                         0:0.1:1, 
-                         Dates.DateTime(2019, 01, 01, 0, 0, 0), 
+                         [0, 0, 1],
+                         0:0.1:1,
+                         Dates.DateTime(2019, 01, 01, 0, 0, 0),
                          latitude_deg=10.0,
                          longitude_deg=20.0,
                          height_m = 1000) do time_s

--- a/src/scanning.jl
+++ b/src/scanning.jl
@@ -28,7 +28,7 @@
 # The code in this file tries to follow the conventions laid in
 # document LSPE-STRIP-SP-017 ("STRIP Telescope Coordinate Systems
 # Specification") as much as possible. As the reader might not be
-# aquainted with it, here is a short summary of the relevant
+# acquainted with it, here is a short summary of the relevant
 # terminology:
 #
 # +-----+-----------------------------+------------------------------------------+

--- a/src/scanning.jl
+++ b/src/scanning.jl
@@ -164,7 +164,13 @@ function telescopetoground(wheelanglesfn, time_s)
     (wheel1ang, wheel2ang, wheel3ang) = wheelanglesfn(time_s)
 
     qwheel1 = qrotation_z(wheel1ang)
-    qwheel2 = qrotation_y(wheel2ang)
+
+    # The minus sign here is required to make the cryostat go down for
+    # positive angles
+    qwheel2 = qrotation_y(-wheel2ang)
+
+    # The minus sign here takes into account the fact that the azimuth
+    # motor requires positive angles to turn North into East
     qwheel3 = qrotation_z(-wheel3ang)
 
     qwheel3 * (qwheel2 * qwheel1)

--- a/src/scanning.jl
+++ b/src/scanning.jl
@@ -1,17 +1,43 @@
-using Quaternions
+import Quaternions
 import Healpix
-using StaticArrays
-using LinearAlgebra
-using AstroLib
-using Dates
+import StaticArrays
+import LinearAlgebra: ×, dot
+import AstroLib
+import Dates
 
 export TENERIFE_LATITUDE_DEG, TENERIFE_LONGITUDE_DEG, TENERIFE_HEIGHT_M
+export qrotation_x, qrotation_y, qrotation_z
 export timetorotang, telescopetoground, groundtoearth
 export genpointings, polarizationangle
 
 const TENERIFE_LATITUDE_DEG = 28.3
 const TENERIFE_LONGITUDE_DEG = -16.509722
 const TENERIFE_HEIGHT_M = 2390
+
+# These functions are faster than Quaternions.qrotation2
+
+function qrotation_x(theta)
+    Quaternions.Quaternion(cos(theta / 2), sin(theta / 2), 0.0, 0.0, true)
+end
+
+function qrotation_y(theta)
+    Quaternions.Quaternion(cos(theta / 2), 0.0, sin(theta / 2), 0.0, true)
+end
+
+function qrotation_z(theta)
+    Quaternions.Quaternion(cos(theta / 2), 0.0, 0.0, sin(theta / 2), true)
+end
+
+"""
+    qrotation_x(theta)
+    qrotation_y(theta)
+    qrotation_z(theta)
+
+Return a `Quaternions.Quaternion` object representing a rotation
+around the ``e_x``, ``e_y``, or ``e_z`` axis by an angle `theta` (in
+radians).
+"""
+qrotation_x, qrotation_y, qrotation_z
 
 
 """
@@ -30,20 +56,27 @@ function timetorotang(time_s, rpm)
 end
 
 
-"""
+@doc raw"""
     telescopetoground(wheelanglesfn, time_s)
 
 Return a quaternion of type `Quaternion{Float64}` representing the
 coordinate transform from the focal plane to the ground of the
 telescope. The parameter `wheelanglesfn` must be a function which
 takes as input a time, `time_s`, in seconds, and it must return a
-3-tuple containing the angles of the following motors:
+3-tuple containing the angles of the following motors, measured in
+**radians**:
 
-1. The boresight motor
-2. The altitude motor
-3. The ground motor
+1. The boresight motor (rotation around the ``z`` axis,
+   counterclockwise)
 
-Example:
+2. The altitude motor (rotation around the ``y`` axis,
+   counterclockwise)
+
+3. The ground motor (rotation around the ``z`` axis, **clockwise**:
+   N→E→S→W)
+
+# Example
+
 `````julia
 telescopetoground(3600.0) do
     # Boresight motor keeps a constant angle equal to 0°
@@ -56,9 +89,9 @@ end
 function telescopetoground(wheelanglesfn, time_s)
     (wheel1ang, wheel2ang, wheel3ang) = wheelanglesfn(time_s)
     
-    qwheel1 = qrotation([0, 0, 1], wheel1ang)
-    qwheel2 = qrotation([1, 0, 0], wheel2ang)
-    qwheel3 = qrotation([0, 0, 1], wheel3ang)
+    qwheel1 = qrotation_z(wheel1ang)
+    qwheel2 = qrotation_y(wheel2ang)
+    qwheel3 = qrotation_z(-wheel3ang)
     
     qwheel3 * (qwheel2 * qwheel1)
 end
@@ -76,11 +109,10 @@ time in seconds, and `latitude_deg` is the latitude (in degrees, N is
 positive) of the location where the observation is made.
 
 The keyword `day_duration_s` specifies the length of a day in seconds.
-
 """
 function groundtoearth(groundq, time_s, latitude_deg; day_duration_s=86400.0)
-    locq = qrotation([1, 0, 0], deg2rad(90 - latitude_deg))
-    earthq = qrotation([0, 0, 1], 2 * π * time_s / day_duration_s)
+    locq = qrotation_y(deg2rad(90 - latitude_deg))
+    earthq = qrotation_z(2π * time_s / day_duration_s)
     
     earthq * (locq * groundq)
 end
@@ -97,30 +129,30 @@ is positive) and the height (in meters) of the location where the observation is
 made. 
 """
 function vector2equatorial(vector, jd, latitude_deg, longitude_deg, height_m)
-    (θ, ϕ) = Healpix.vec2ang(vector[1], vector[2], vector[3])
-    Alt_rad = π/2 - θ 
-    Az_rad = 2π - ϕ
+    (θ, ϕ) = Healpix.vec2ang(vector...)
+    alt_rad = π/2 - θ 
+    az_rad = 2π - ϕ
     
-    Ra_deg, Dec_deg, HA_deg = AstroLib.hor2eq(rad2deg(Alt_rad),
-                                              rad2deg(Az_rad),
-                                              jd,
-                                              latitude_deg,
-                                              longitude_deg,
-                                              height_m,
-                                              precession=true,
-                                              nutate=true,
-                                              aberration=true)
-    (deg2rad(Dec_deg), deg2rad(Ra_deg))
+    ra_deg, dec_deg, _ = AstroLib.hor2eq(rad2deg(alt_rad),
+                                         rad2deg(az_rad),
+                                         jd,
+                                         latitude_deg,
+                                         longitude_deg,
+                                         height_m,
+                                         precession=true,
+                                         nutate=true,
+                                         aberration=true)
+    (deg2rad(dec_deg), deg2rad(ra_deg))
 end
 
 
 """
     polarizationangle(northdir, poldir)
 
-Calculate the polarization angle projected in the sky in IAU conventions.
-The parameter `northdir` must be a versor that points the North and `poldir`
-must be a versor that identify the polarization direction projected in the sky.
-The return value is in radians.
+Calculate the polarization angle projected in the sky in IAU
+conventions.  The parameter `northdir` must be a versor that points
+the North and `poldir` must be a versor that identify the polarization
+direction projected in the sky.  The return value is in radians.
 """
 function polarizationangle(northdir, poldir)
     cosψ = clamp(dot(northdir, poldir), -1, 1)
@@ -134,49 +166,34 @@ end
 """
     get_northdir(θ, ϕ)
 
-Compute the North of a vector. The North for a vector v is just -dv/dθ, as θ is 
-the colatitude and moves along the meridian
+Compute the North of a vector. The North for a vector v is -dv/dθ, as
+θ is the colatitude and moves along the meridian.
 """
-get_northdir(θ, ϕ) = @SArray [-cos(θ) * cos(ϕ), -cos(θ) * sin(ϕ), sin(θ)]
+get_northdir(θ, ϕ) = StaticArrays.@SArray [-cos(θ) * cos(ϕ), -cos(θ) * sin(ϕ), sin(θ)]
 
 
 """
-    genpointings(wheelanglesfn, dir, timerange_s; latitude_deg=0.0, 
-                 ground=false)
+    quat_to_angles(boreaxis, polaxis, quat)
 
-Generate a set of pointings for some STRIP detector. The parameter
-`wheelanglesfn` must be a function which takes as input a time in seconds
-and returns a 3-tuple containing the angles (in radians) of the three
-motors:
-1. The boresight motor
-2. The altitude motor
-3. The ground motor
+Transform the boresight direction `dir` and the polarization direction
+`poldir` according to quaternion `quat`. Return the 3-tuple (θ, ϕ, ψ)
+representing the colatitude, longitude, and polarization angle
+(calculated northward).
 
-The parameter `dir` must be a normalized vector which tells the pointing
-direction of the beam (boresight is [0, 0, 1]). The parameter `timerange_s`
-is either a range or a vector which specifies at which times (in second)
-the pointings should be computed. The keyword `latitude_deg` should contain
-the latitude (in degrees, N is positive) of the location where the observation
-is made. The keyword `ground` must be a boolean: if true the function will return
-a 4-tuple containing coordinates referred to the ground coordinate system (column
- 3 and 4) and the equatorial coordinates (column 1 and 2). Otherwise, if false 
-the function will return a 2-tuple coordinates only expressed in equatorial 
-coordinates; default is false.
+This function is used internally by `genpointings`.
+"""
+function quat_to_angles(boreaxis, polaxis, quat)
+    rotmatr = Quaternions.rotationmatrix(quat)
+    boresight = rotmatr * boreaxis
+    poldir = rotmatr * polaxis
+            
+    (θ, ϕ) = Healpix.vec2ang(boresight...)
 
-Return a 2-tuple (4-tuple) containing the directions (a N×2 (Nx4) array 
-containing the colatitude and the longitude) and the polarization angles at each 
-time step.
-
-Example:
-`````julia
-genpointings([0, 0, 1], 0:0.1:1) do time_s
-    # Boresight motor keeps a constant angle equal to 0°
-    # Altitude motor remains at 20° from the Zenith
-    # Ground motor spins at 1 RPM
-    return (0.0, deg2rad(20.0), timetorotang(time_s, 1))
+    northdir = get_northdir(θ, ϕ)
+    (θ, ϕ, polarizationangle(northdir, poldir))
 end
-`````
-"""
+
+
 function genpointings(wheelanglesfn,
                       dir,
                       timerange_s;
@@ -194,57 +211,25 @@ function genpointings(wheelanglesfn,
     zaxis = [1; 0; 0] #should be different for each horn...
     for (idx, time_s) = enumerate(timerange_s)
         
-        # This is in the ground reference frame
+        # This converts the RDP into the MCS (ground reference frame)
         groundq = telescopetoground(wheelanglesfn, time_s)
+        # This converts the MCS into the celestial reference frame
+        quat = groundtoearth(groundq, time_s, latitude_deg)
+
+        θ, ϕ, curψ = quat_to_angles(dir, zaxis, quat)
+
+        (dirs[idx, 1], dirs[idx, 2]) = (θ, ϕ) 
+        northdir = get_northdir(θ, ϕ)
         
         if ground
-            rotmatr_ground = rotationmatrix(groundq)
-            quat = groundtoearth(groundq, time_s, latitude_deg)
-            rotmatr_earth = rotationmatrix(quat)
+            # Re-run the transformation algorithm using the ground quaternion
+            θ_ground, ϕ_ground, ψ_ground = quat_to_angles(dir, zaxis, groundq)
 
-            vector_ground = rotmatr_ground * dir
-            poldir_ground = rotmatr_ground * zaxis
-            
-            vector_earth = rotmatr_earth * dir
-            poldir_earth = rotmatr_earth * zaxis
-
-            # The North for a vector v is just -dv/dθ, as θ is the
-            # colatitude and moves along the meridian
-            (θ_earth, ϕ_earth) = Healpix.vec2ang(vector_earth[1],
-                                                 vector_earth[2],
-                                                 vector_earth[3])
-            (θ_ground, ϕ_ground) = Healpix.vec2ang(vector_ground[1],
-                                                   vector_ground[2],
-                                                   vector_ground[3])
-            dirs[idx, 1] = θ_earth
-            dirs[idx, 2] = ϕ_earth
-
-            dirs[idx, 3] = θ_ground
-            dirs[idx, 4] = ϕ_ground
-
-            northdir_earth = get_northdir(θ_earth, ϕ_earth)
-            northdir_ground = get_northdir(θ_ground, ϕ_ground)
-
-            ψ[idx, 1] = polarizationangle(northdir_earth, poldir_earth)
-            ψ[idx, 2] = polarizationangle(northdir_ground, poldir_ground)
-
-
+            (dirs[idx, 1], dirs[idx, 2], dirs[idx, 3], dirs[idx, 4]) = (θ, ϕ, θ_ground, ϕ_ground)
+            (ψ[idx, 1], ψ[idx, 2]) = (curψ, ψ_ground)
         else
-            # Now from the ground reference frame to the Earth reference frame
-            quat = groundtoearth(groundq, time_s, latitude_deg)
-            rotmatr = rotationmatrix(quat)
-
-            vector = rotmatr * dir
-            poldir = rotmatr * zaxis
-
-            # The North for a vector v is just -dv/dθ, as θ is the
-            # colatitude and moves along the meridian
-            (θ, ϕ) = Healpix.vec2ang(vector[1], vector[2], vector[3])
-            dirs[idx, 1] = θ
-            dirs[idx, 2] = ϕ
-            northdir = get_northdir(θ, ϕ)
-            ψ[idx] = polarizationangle(northdir, poldir)
-            
+            (dirs[idx, 1], dirs[idx, 2]) = (θ, ϕ)
+            ψ[idx] = curψ
         end
     end
     
@@ -252,47 +237,6 @@ function genpointings(wheelanglesfn,
 end
 
 
-"""
-    genpointings(wheelanglesfn, dir, timerange_s, t_start, t_stop; 
-                 latitude_deg=0.0, longitude_deg=0.0, height_m=0.0)
-
-Generate a set of pointings for some STRIP detector. The parameter
-`wheelanglesfn` must be a function which takes as input a time in seconds
-and returns a 3-tuple containing the angles (in radians) of the three
-motors:
-1. The boresight motor
-2. The altitude motor
-3. The ground motor
-
-The parameter `dir` must be a normalized vector which tells the pointing
-direction of the beam (boresight is [0, 0, 1]). The parameter `timerange_s`
-is either a range or a vector which specifies at which times (in second)
-the pointings should be computed. The parameter `t_start` must be a DateTime 
-which tells the exact UTC date and time of the observation. The keywords 
-`latitude_deg`, `longitude_deg` and `height_m` should contain the latitude 
-(in degrees, N is positive), the longitude (in degrees, counterclockwise is 
-positive) and the height (in meters) of the location where the observation is  
-made.
-
-Return a 2-tuple containing the sky directions (a N×2 array containing the 
-Declination and the RightAscension) and the polarization angle given in 
-equatorial coordinates at each time step.
-
-Example:
-`````julia
-genpointings([0, 0, 1], 
-             0:0.1:1, 
-             DateTime(2019, 01, 01, 0, 0, 0), 
-             latitude_deg=10.0,
-             longitude_deg=20.0,
-             height_m = 1000) do time_s
-    # Boresight motor keeps a constant angle equal to 0°
-    # Altitude motor remains at 20° from the Zenith
-    # Ground motor spins at 1 RPM
-    return (0.0, deg2rad(20.0), timetorotang(time_s, 1))
-end
-`````
-"""
 function genpointings(wheelanglesfn,
                       dir,
                       timerange_s,
@@ -310,7 +254,7 @@ function genpointings(wheelanglesfn,
         # This is in the ground reference frame
         groundq = telescopetoground(wheelanglesfn, time_s)
         
-        rotmatr = rotationmatrix(groundq)
+        rotmatr = Quaternions.rotationmatrix(groundq)
         vector = rotmatr * dir
 
         jd = AstroLib.jdcnv(t_start + Dates.Nanosecond(round(Int64, time_s*1e9)))
@@ -330,12 +274,12 @@ function genpointings(wheelanglesfn,
         #                                           longitude_deg,
         #                                           height_m)
         
-        # skypoldir = @SArray [cos(Decpol_rad) * cos(Rapol_rad),
-        #                      cos(Decpol_rad) * sin(Rapol_rad),
-        #                      sin(Decpol_rad)]
-        # skynorthdir = @SArray [-sin(Decpol_rad) * cos(Rapol_rad),
-        #                        -sin(Decpol_rad) * sin(Rapol_rad),
-        #                        cos(Decpol_rad)]
+        # skypoldir = StaticArrays.@SArray [cos(Decpol_rad) * cos(Rapol_rad),
+        #                                   cos(Decpol_rad) * sin(Rapol_rad),
+        #                                   sin(Decpol_rad)]
+        # skynorthdir = StaticArrays.@SArray [-sin(Decpol_rad) * cos(Rapol_rad),
+        #                                     -sin(Decpol_rad) * sin(Rapol_rad),
+        #                                     cos(Decpol_rad)]
         
         # skyψ[idx] = polarizationangle(skynorthdir, skypoldir)
         skyψ[idx] = 0.
@@ -343,3 +287,84 @@ function genpointings(wheelanglesfn,
 
     (skydirs, skyψ) # The polarization angle is still missing
 end
+
+
+@doc raw"""
+    genpointings(wheelanglesfn, dir, timerange_s; latitude_deg=0.0, 
+                 ground=false)
+    genpointings(wheelanglesfn, dir, timerange_s, t_start, t_stop; 
+                 latitude_deg=0.0, longitude_deg=0.0, height_m=0.0)
+
+Generate a set of pointings for a STRIP detector. The parameter
+`wheelanglesfn` must be a function which takes as input a time in
+seconds and returns a 3-tuple containing the angles (in radians) of
+the three motors:
+
+1. The boresight motor (rotation around the ``z`` axis,
+   counterclockwise)
+
+2. The altitude motor (rotation around the ``y`` axis,
+   counterclockwise)
+
+3. The ground motor (rotation around the ``z`` axis, **clockwise**:
+   N→E→S→W)
+
+The meaning of the parameters is the following:
+
+- `dir` specifies the pointing direction of the mean (the boresight is
+  [0, 0, 1]). It must be normalized.
+
+- `timerange_s` is an enumerable type that specifies at which times
+  (in seconds) pointings must be computed.
+
+- `latitude_deg` is the latitude of the location where the observation
+is made (in degrees, North is positive).
+
+- `ground` is a Boolean: if `true`, the function will return a 4-tuple
+  containing the colatitude and longitude measured in Equatorial
+  coordinates (columns 1 and 2) and in ground coordinates (columns 3
+  and 4). If false, only the Equatorial coordinates are computed.
+
+
+# Return values
+
+In the first form, the function returns a 2-tuple containing the sky
+directions (a N×2 array containing declination and right ascension, in
+Equatorial coordinates) and the polarization angle for each time step.
+
+In the second form, the function returns a 2-tuple (4-tuple)
+containing the directions (a N×2 or Nx4 array containing the
+colatitude and the longitude) and the polarization angles at each time
+step.
+
+
+# Examples
+
+Here is an example of the first kind:
+
+`````julia
+dir, psi = genpointings([0, 0, 1], 0:0.1:1) do time_s
+    # Boresight motor keeps a constant angle equal to 0°
+    # Altitude motor remains at 20° from the Zenith
+    # Ground motor spins at 1 RPM
+    return (0.0, deg2rad(20.0), timetorotang(time_s, 1))
+end
+`````
+
+And here is an example of the second kind. Note that, unlike the
+previous example, we use a lambda function instead of the `do...end`
+notation.
+
+`````julia
+import Dates
+
+dirs, psi = genpointings(time_s -> (0, deg2rad(20), timetorotang(time_s, 1)),
+                         [0, 0, 1], 
+                         0:0.1:1, 
+                         Dates.DateTime(2019, 01, 01, 0, 0, 0), 
+                         latitude_deg=10.0,
+                         longitude_deg=20.0,
+                         height_m = 1000) do time_s
+`````
+"""
+genpointings

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,38 +1,22 @@
 using Test
 using Stripeline
 
-# Scanning strategy
-
-(dirs, psi) = genpointings([0., 0., 1.], 0.:20.:60., latitude_deg=0.0) do time_s
-    wheel1ang = 0.0
-    wheel2ang = 30.0
-    wheel3ang = timetorotang(time_s, 1.0)
-
-    (wheel1ang, wheel2ang, wheel3ang)
+@testset "Instrument database" begin
+    include("instrumentdb_tests.jl")
+end
+    
+@testset "Scanning strategy" begin
+    include("scanning.jl")
 end
 
-@test size(dirs) == (4, 2)
-@test length(psi) == 4
-#@test dirs ≈ [0.15487 4.71239; 2.0875 3.3214; 2.0875 6.10774; 0.15487 4.71675], atol = 1e-5
-# This fails, but we have to revise the way polarization angles are calculated
-#@test psi ≈ [0, π / 2, π, 3π / 4]
+@testset "Map maker" begin
+    include("map_maker_tests.jl")
+end
 
-# Instrument DB
+@testset "TOD splitter" begin
+    include("tod_splitter_tests.jl")
+end
 
-include("instrumentdb_tests.jl")
-
-# Map-maker
-
-include("map_maker_tests.jl")
-
-# TOD-splitter
-
-include("tod_splitter_tests.jl")
-
-# Noise Generation
-
-include("noisegeneration_tests.jl")
-
-# Scanning 
-
-include("scanning.jl")
+@testset "Noise generation" begin
+    include("noisegeneration_tests.jl")
+end

--- a/test/scanning.jl
+++ b/test/scanning.jl
@@ -18,30 +18,24 @@ crab_ra_astropy_rad = 1.4596726619436968
 crab_dec_astropy_rad = 0.3842255081802917 
 crab_position = sqrt(crab_ra_astropy_rad^2 + crab_dec_astropy_rad^2)
 
-# Invert crab coordinates into telescope pointing directions
-qwheel1 = qrotation([0, 0, 1], 0)
-qwheel2 = qrotation([1, 0, 0], deg2rad(20.))
-qwheel3 = qrotation([0, 0, 1], 0)
-
-groundq = qwheel3 * (qwheel2 * qwheel1)
+# Invert Crab coordinates into telescope pointing directions
+groundq = telescopetoground(_ -> (0, deg2rad(20), 0), 0)
 rotmatr = rotationmatrix(groundq)
-vector = Healpix.ang2vec(dirs[1], dirs[2])
+vector = Healpix.ang2vec(dirs...)
 dir = inv(rotmatr) * vector
 
 # Compute skydirs
-(skydirs, skyψ) = genpointings(dir, 
-                               0.:1.:0., 
+(skydirs, skyψ) = genpointings(_ -> (0, deg2rad(20), 0),
+                               dir, 
+                               [0],
                                t_start, 
-                               latitude_deg=TENERIFE_LATITUDE_DEG,
-                               longitude_deg=TENERIFE_LONGITUDE_DEG,
-                               height_m=TENERIFE_HEIGHT_M) do time_s
-                                   return (0., deg2rad(20.0), 0.)
-                               end
-crab_position_skydirs = sqrt(skydirs[1, 1]^2 + skydirs[1, 2]^2)
-
-@test skydirs[1, 1] ≈ crab_dec_astropy_rad atol = eps
-@test skydirs[1, 2] ≈ crab_ra_astropy_rad atol = eps
-@test crab_position_skydirs ≈ crab_position atol = eps
+                               latitude_deg = TENERIFE_LATITUDE_DEG,
+                               longitude_deg = TENERIFE_LONGITUDE_DEG,
+                               height_m = TENERIFE_HEIGHT_M)
+crab_position_skydirs = sqrt(skydirs[1]^2 + skydirs[2]^2)
+@test skydirs[1] ≈ crab_dec_astropy_rad atol=eps
+@test skydirs[2] ≈ crab_ra_astropy_rad atol=eps
+@test crab_position_skydirs ≈ crab_position atol=eps
 
 t_1 = DateTime(2019, 02, 01, 2, 0, 0)
 t_2 = DateTime(2019, 02, 02, 2, 0, 0) 
@@ -63,14 +57,13 @@ for (idx, day) in enumerate(days)
     vector = Healpix.ang2vec(dirs[idx, 1], dirs[idx, 2])
     dir = inv(rotmatr) * vector
 
-    (skydirections, skyψ) = genpointings(dir, 
-                                         0.:1.:0., 
+    (skydirections, skyψ) = genpointings(_ -> (0, deg2rad(20), 0),
+                                         dir, 
+                                         [0], 
                                          day, 
-                                         latitude_deg=TENERIFE_LATITUDE_DEG,
-                                         longitude_deg=TENERIFE_LONGITUDE_DEG,
-                                         height_m=TENERIFE_HEIGHT_M) do time_s
-                                             return (0., deg2rad(20.0), 0.)
-                                         end
+                                         latitude_deg = TENERIFE_LATITUDE_DEG,
+                                         longitude_deg = TENERIFE_LONGITUDE_DEG,
+                                         height_m = TENERIFE_HEIGHT_M)
 
     skydirs[idx, 1] = skydirections[1]
     skydirs[idx, 2] = skydirections[2]
@@ -78,16 +71,15 @@ end
 
 crab_position_skydirs = sqrt.(skydirs[:, 1].^2 + skydirs[:, 2].^2)
 
-@test skydirs[1, 1] ≈ crab_dec_astropy_rad atol = eps
-@test skydirs[1, 2] ≈ crab_ra_astropy_rad atol = eps
-@test skydirs[2, 1] ≈ crab_dec_astropy_rad atol = eps
-@test skydirs[2, 2] ≈ crab_ra_astropy_rad atol = eps
-@test skydirs[3, 1] ≈ crab_dec_astropy_rad atol = eps
-@test skydirs[3, 2] ≈ crab_ra_astropy_rad atol = eps
-@test crab_position_skydirs[1] ≈ crab_position atol = eps
-@test crab_position_skydirs[2] ≈ crab_position atol = eps
-@test crab_position_skydirs[3] ≈ crab_position atol = eps
-
+@test skydirs[1, 1] ≈ crab_dec_astropy_rad atol=eps
+@test skydirs[1, 2] ≈ crab_ra_astropy_rad atol=eps
+@test skydirs[2, 1] ≈ crab_dec_astropy_rad atol=eps
+@test skydirs[2, 2] ≈ crab_ra_astropy_rad atol=eps
+@test skydirs[3, 1] ≈ crab_dec_astropy_rad atol=eps
+@test skydirs[3, 2] ≈ crab_ra_astropy_rad atol=eps
+@test crab_position_skydirs[1] ≈ crab_position atol=eps
+@test crab_position_skydirs[2] ≈ crab_position atol=eps
+@test crab_position_skydirs[3] ≈ crab_position atol=eps
 
 # Test flag `ground`
 db = Sl.InstrumentDB()
@@ -102,24 +94,30 @@ times = 0:τ_s:time_duration
 (dirs, ψ) = genpointings(db.focalplane["I0"].orientation, 
                          times; 
                          latitude_deg=TENERIFE_LATITUDE_DEG) do time_s
-                             return (0.,
-                                     deg2rad(20.0),
-                                     Sl.timetorotang(time_s, spin_velocity))
+                             (0,
+                              deg2rad(20.0),
+                              Sl.timetorotang(time_s, spin_velocity))
                          end
 
-@test size(dirs) == (convert(Int64, time_duration * sampling_rate + 1), 2)
-@test size(ψ) == (convert(Int64, time_duration * sampling_rate + 1), )
+expected_nsamples = convert(Int, time_duration * sampling_rate + 1)
+@test size(dirs) == (expected_nsamples, 2)
+@test size(ψ) == (expected_nsamples, )
 
 (dirs, ψ) = genpointings(db.focalplane["I0"].orientation, 
                          times;
                          ground=true,
                          latitude_deg=TENERIFE_LATITUDE_DEG) do time_s
-                             return (0.,
-                                     deg2rad(20.0),
-                                     Sl.timetorotang(time_s, spin_velocity))
+                             (0,
+                              deg2rad(20.0),
+                              Sl.timetorotang(time_s, spin_velocity))
                          end
 
-@test size(dirs) == (convert(Int64, time_duration * sampling_rate + 1), 4)
+expected_nsamples = convert(Int, time_duration * sampling_rate + 1)
+@test size(dirs) == (expected_nsamples, 4)
+@test size(ψ) == (expected_nsamples, 2)
+
+# Check that all the values in the 3rd column are the same
 @test dirs[1:end-1, 3] ≈ dirs[2:end, 3]
-@test size(ψ) == (convert(Int64, time_duration * sampling_rate + 1), 2)
-@test rad2deg(dirs[1, 3]) ≈ 20.0 atol = 1e-8
+
+# We strieve for an accuracy of a few arcseconds
+@test rad2deg(dirs[1, 3]) ≈ 20.0 atol=1e-3

--- a/test/scanning.jl
+++ b/test/scanning.jl
@@ -121,3 +121,25 @@ expected_nsamples = convert(Int, time_duration * sampling_rate + 1)
 
 # We strieve for an accuracy of a few arcseconds
 @test rad2deg(dirs[1, 3]) ≈ 20.0 atol=1e-3
+
+################################################################################
+
+# Check that the sign of the wheel angles is correct
+
+let defaultdb = InstrumentDB()
+    wheelfn(time_s) = (0, deg2rad(20), Stripeline.timetorotang(time_s, 1))
+
+    # We do not start from t = 0s because we want the longitude to be positive
+    timerange = 7200:1:(7200 + 60)
+    G0_vec = defaultdb.focalplane["G0"].orientation
+    V0_vec = defaultdb.focalplane["V0"].orientation
+    
+    dirG0, psiG0 = Stripeline.genpointings(wheelfn, G0_vec, timerange)
+    dirV0, psiV0 = Stripeline.genpointings(wheelfn, V0_vec, timerange)
+
+    # We expect G0 to draw larger circles in the sky
+    @test minimum(dirG0[:, 1]) < minimum(dirV0[:, 1])
+    @test minimum(dirG0[:, 1]) < minimum(dirV0[:, 1])
+    @test maximum(dirG0[:, 1]) > maximum(dirV0[:, 1])
+    @test maximum(dirG0[:, 2]) > maximum(dirV0[:, 2])
+end


### PR DESCRIPTION
This PR is a work in progress to conform Stripeline's coordinate systems with the one defined in the document LSPE-STRIP-SP-017 ("STRIP Telescope Coordinate Systems Specification"). The patch fixes a number of things:

* All the coordinate systems and the zero-points of the motor angles conform to the specification document;
* It is now possible to specify the *true* polarization axis in `genpointings`, using the keyword `polaxis`;
* Quaternion calculations are more efficient and faster
* The code is more modular and easy to modify

I am keeping this PR open in order to do some more tests on `genpointings` before merging to master.