### PR TITLE
get measured fknees directly from database

### DIFF
--- a/src/DBforsimulation.jl
+++ b/src/DBforsimulation.jl
@@ -23,24 +23,25 @@ import Random
 
 """
 function get_info_from_DB(db, horns)
+
     orientations=[]
     polarimeters = Array{Int64}(undef, length(horns))
     β_hz = Array{Float64}(undef,length(horns))
     tnoise_k = Array{Float64}(undef,length(horns))
     fknee_hz = Array{Float64}(undef,length(horns))
 
-    measured_fknees = [0.13, 0.04, 1.3, 0.06, 0.23, 0.025, 0.016,
-    0.9, 0.12, 0.3, 0.2, 0.09, 0.31, 0.05, 
-    0.1, 0.02, 0.027, 0.07, 0.02, 0.014, 0.007,
-    0.41, 0.4, 0.09, 0.138, 0.05, 0.17, 0.6, 
-    0.028, 0.0048, 0.01, 0.058, 0.01, 0.08, 
-    0.016, 0.09]
+    measured_fknees = Float64[]
+    for i in 1:length(horns)
+        polarimeters[i] = db.focalplane[horns[i]].polid
+        if(db.detectors[polarimeters[i]].spectrum.fknee_q_hz !=0)
+            push!(measured_fknees, db.detectors[polarimeters[i]].spectrum.fknee_q_hz)
+        end
+    end
 
     rng = Random.MersenneTwister(1234)
 
     for i in 1:length(horns)
         append!(orientations, [db.focalplane[horns[i]].orientation])
-        polarimeters[i] = db.focalplane[horns[i]].polid
         β_hz[i] = db.detectors[polarimeters[i]].bandshape.bandwidth_hz
         tnoise_k[i] = db.detectors[polarimeters[i]].tnoise.tnoise_k
           
@@ -50,9 +51,7 @@ function get_info_from_DB(db, horns)
             fknee_hz[i] = db.detectors[polarimeters[i]].spectrum.fknee_q_hz
         end
     end
-
     return orientations, polarimeters, β_hz, tnoise_k, fknee_hz
 
 end
-
 


### PR DESCRIPTION
Now `get_info_from_DB` no more picks 1/f knee frequencies (for polarimeters without direct measurement) from a pre-existent array.  The array `measured_fknees`  is now built by looking at the DB every time the function is called.
