### PR TITLE
Add a high-level API for the instrument db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # HEAD
 
 - Add functions to simulate ADCs [#24](https://github.com/lspestrip/Stripeline.jl/pull/24)
+- Add a high-level API for accessing the instrument database [#30](https://github.com/lspestrip/Stripeline.jl/pull/30)
 
 # Version 0.4
 

--- a/docs/src/instrumentdb.md
+++ b/docs/src/instrumentdb.md
@@ -80,7 +80,7 @@ NoiseTemperatureInfo
 detector
 bandpass
 spectrum
-fknee
+fknee_hz
 tnoise
 ```
 

--- a/docs/src/instrumentdb.md
+++ b/docs/src/instrumentdb.md
@@ -32,8 +32,21 @@ db.focalplane["I0"]
 db.detectors[2]
 ```
 
-The structure `Detector` is complex, as it is built over three other
-structures:
+A number of high-level functions ease the access of the fields in a
+[`InstrumentDB`](@ref) object:
+
+- [`detector`](@ref) returns a [`Detector`](@ref) structure, containing the
+  details of a polarimeter;
+- [`bandpass`](@ref) returns the shape of the bandpass of a detector, as a pair of
+  arrays containing the frequency and the band response, respectively;
+- [`spectrum`](@ref) returns a [`SpectrumInfo`](@ref)
+- [`fknee`](@ref) returns the knee frequency of the 1/f noise for the I, Q, and
+  U signals, adapted to the brightness temperature of the load being observed by
+  the detector;
+- [`tnoise`](@ref) returns the noise temperature for the I, Q, and U components.
+
+The structure `Detector` uses three structures to organize its data in a
+hierarchical way:
 
 - [`BandshapeInfo`](@ref)
 - [`SpectrumInfo`](@ref)
@@ -59,6 +72,16 @@ Detector
 BandshapeInfo
 SpectrumInfo
 NoiseTemperatureInfo
+```
+
+## High-level access functions
+
+```@docs
+detector
+bandpass
+spectrum
+fknee
+tnoise
 ```
 
 ## Loading custom databases

--- a/instrumentdb/strip_detectors.yaml
+++ b/instrumentdb/strip_detectors.yaml
@@ -154,7 +154,8 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.0007, Q_fknee_hz: 0.0077,
     Q_slope: 2.217, Q_slope_err: 0.004, Q_wn_level_err_k2_hz: 2.0e-07, Q_wn_level_k2_hz: 1.9e-06,
     U_fknee_err_hz: 0.0009, U_fknee_hz: 0.0062, U_slope: 1.816, U_slope_err: 0.007,
-    U_wn_level_err_k2_hz: 1.0e-07, U_wn_level_k2_hz: 1.2e-06, analysis_id: 17, test_id: 239}
+    U_wn_level_err_k2_hz: 1.0e-07, U_wn_level_k2_hz: 1.2e-06, analysis_id: 17, load_a_temperature_k: 22.75078475,
+    load_average_temperature_k: 21.330017375, load_b_temperature_k: 19.90925, test_id: 239}
   tnoise:
     analysis_ids: [107, 108]
     test_ids: [125, 126]
@@ -372,7 +373,8 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.03, Q_fknee_hz: 0.05,
     Q_slope: 0.736, Q_slope_err: 0.01, Q_wn_level_err_k2_hz: 2.0e-06, Q_wn_level_k2_hz: 7.0e-06,
     U_fknee_err_hz: 0.03, U_fknee_hz: 0.04, U_slope: 0.38, U_slope_err: 0.005, U_wn_level_err_k2_hz: 1.0e-06,
-    U_wn_level_k2_hz: 4.0e-06, analysis_id: 20, test_id: 208}
+    U_wn_level_k2_hz: 4.0e-06, analysis_id: 20, load_a_temperature_k: 22.686223000000005,
+    load_average_temperature_k: 21.2922365, load_b_temperature_k: 19.89825, test_id: 208}
   tnoise:
     analysis_ids: [32, 33]
     test_ids: [272, 273]
@@ -484,7 +486,8 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.002, Q_fknee_hz: 0.014,
     Q_slope: 2.516, Q_slope_err: 0.008, Q_wn_level_err_k2_hz: 3.0e-07, Q_wn_level_k2_hz: 2.5e-06,
     U_fknee_err_hz: 0.0008, U_fknee_hz: 0.0094, U_slope: 2.076, U_slope_err: 0.004,
-    U_wn_level_err_k2_hz: 3.0e-07, U_wn_level_k2_hz: 2.2e-06, analysis_id: 22, test_id: 489}
+    U_wn_level_err_k2_hz: 3.0e-07, U_wn_level_k2_hz: 2.2e-06, analysis_id: 22, load_a_temperature_k: 22.732807750000003,
+    load_average_temperature_k: 21.308653875, load_b_temperature_k: 19.8845, test_id: 489}
   tnoise:
     analysis_ids: [111, 112]
     test_ids: [460, 461]
@@ -883,7 +886,8 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.9, Q_fknee_hz: 4.5,
     Q_slope: 0.34967, Q_slope_err: 2.0e-05, Q_wn_level_err_k2_hz: 3.5, Q_wn_level_k2_hz: 48.8,
     U_fknee_err_hz: 2.4, U_fknee_hz: 6.1, U_slope: 0.577706, U_slope_err: 5.0e-06,
-    U_wn_level_err_k2_hz: 134.02, U_wn_level_k2_hz: 588.04, analysis_id: 25, test_id: 406}
+    U_wn_level_err_k2_hz: 134.02, U_wn_level_k2_hz: 588.04, analysis_id: 25, load_a_temperature_k: 22.72730775,
+    load_average_temperature_k: 21.305903875, load_b_temperature_k: 19.8845, test_id: 406}
 - band: Q
   bandpass:
     analysis_id: 112
@@ -933,7 +937,8 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.002, Q_fknee_hz: 0.002,
     Q_slope: 1.28, Q_slope_err: 0.02, Q_wn_level_err_k2_hz: 2.0e-06, Q_wn_level_k2_hz: 8.0e-06,
     U_fknee_err_hz: 0.005, U_fknee_hz: 0.004, U_slope: 1.01, U_slope_err: 0.03, U_wn_level_err_k2_hz: 1.0e-06,
-    U_wn_level_k2_hz: 4.0e-06, analysis_id: 26, test_id: 413}
+    U_wn_level_k2_hz: 4.0e-06, analysis_id: 26, load_a_temperature_k: 22.75480775,
+    load_average_temperature_k: 21.319653875, load_b_temperature_k: 19.8845, test_id: 413}
   tnoise:
     analysis_ids: [102, 103]
     test_ids: [425, 426]
@@ -1038,7 +1043,8 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.002, Q_fknee_hz: 0.01,
     Q_slope: 1.4604, Q_slope_err: 0.0009, Q_wn_level_err_k2_hz: 1.0e-06, Q_wn_level_k2_hz: 5.0e-06,
     U_fknee_err_hz: 0.003, U_fknee_hz: 0.011, U_slope: 0.915, U_slope_err: 0.001,
-    U_wn_level_err_k2_hz: 7.0e-07, U_wn_level_k2_hz: 3.0e-06, analysis_id: 27, test_id: 202}
+    U_wn_level_err_k2_hz: 7.0e-07, U_wn_level_k2_hz: 3.0e-06, analysis_id: 27, load_a_temperature_k: 22.7504155,
+    load_average_temperature_k: 21.32983275, load_b_temperature_k: 19.90925, test_id: 202}
   tnoise:
     analysis_ids: [46, 47]
     test_ids: [64, 119]
@@ -1137,7 +1143,8 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.004, Q_fknee_hz: 0.027,
     Q_slope: 0.943, Q_slope_err: 0.003, Q_wn_level_err_k2_hz: 3.0e-07, Q_wn_level_k2_hz: 2.9e-06,
     U_fknee_err_hz: 0.005, U_fknee_hz: 0.035, U_slope: 0.811, U_slope_err: 0.003,
-    U_wn_level_err_k2_hz: 2.0e-07, U_wn_level_k2_hz: 2.4e-06, analysis_id: 79, test_id: 625}
+    U_wn_level_err_k2_hz: 2.0e-07, U_wn_level_k2_hz: 2.4e-06, analysis_id: 79, load_a_temperature_k: 22.086800500000003,
+    load_average_temperature_k: 21.14790025, load_b_temperature_k: 20.209, test_id: 625}
   tnoise:
     analysis_ids: [51]
     test_ids: [244]
@@ -1295,7 +1302,9 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.004, Q_fknee_hz: 0.02,
     Q_slope: 1.3278, Q_slope_err: 0.0007, Q_wn_level_err_k2_hz: 4.0e-07, Q_wn_level_k2_hz: 1.8e-06,
     U_fknee_err_hz: 0.004, U_fknee_hz: 0.018, U_slope: 0.9673, U_slope_err: 0.0007,
-    U_wn_level_err_k2_hz: 4.0e-07, U_wn_level_k2_hz: 1.6e-06, analysis_id: 30, test_id: 234}
+    U_wn_level_err_k2_hz: 4.0e-07, U_wn_level_k2_hz: 1.6e-06, analysis_id: 30, load_a_temperature_k: 22.729154000000005,
+    load_average_temperature_k: 21.316452000000005, load_b_temperature_k: 19.903750000000002,
+    test_id: 234}
   tnoise:
     analysis_ids: [54, 55]
     test_ids: [235, 236]
@@ -1411,7 +1420,9 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.1, Q_fknee_hz: 0.4,
     Q_slope: 0.62, Q_slope_err: 0.001, Q_wn_level_err_k2_hz: 5.0e-07, Q_wn_level_k2_hz: 2.7e-06,
     U_fknee_err_hz: 0.1, U_fknee_hz: 0.3, U_slope: 0.512, U_slope_err: 0.002, U_wn_level_err_k2_hz: 4.0e-07,
-    U_wn_level_k2_hz: 2.4e-06, analysis_id: 32, test_id: 211}
+    U_wn_level_k2_hz: 2.4e-06, analysis_id: 32, load_a_temperature_k: 22.726569250000004,
+    load_average_temperature_k: 21.311034625000005, load_b_temperature_k: 19.895500000000002,
+    test_id: 211}
   tnoise:
     analysis_ids: [56, 57]
     test_ids: [224, 225]
@@ -1522,7 +1533,9 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.002, Q_fknee_hz: 0.016,
     Q_slope: 1.821, Q_slope_err: 0.005, Q_wn_level_err_k2_hz: 2.0e-07, Q_wn_level_k2_hz: 1.9e-06,
     U_fknee_err_hz: 0.002, U_fknee_hz: 0.013, U_slope: 1.232, U_slope_err: 0.006,
-    U_wn_level_err_k2_hz: 2.0e-07, U_wn_level_k2_hz: 1.7e-06, analysis_id: 34, test_id: 199}
+    U_wn_level_err_k2_hz: 2.0e-07, U_wn_level_k2_hz: 1.7e-06, analysis_id: 34, load_a_temperature_k: 22.67485375,
+    load_average_temperature_k: 21.298926875, load_b_temperature_k: 19.923000000000002,
+    test_id: 199}
   tnoise:
     analysis_ids: [58, 59]
     test_ids: [216, 217]
@@ -1579,7 +1592,8 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.0007, Q_fknee_hz: 0.0048,
     Q_slope: 1.689, Q_slope_err: 0.004, Q_wn_level_err_k2_hz: 4.0e-07, Q_wn_level_k2_hz: 2.0e-06,
     U_fknee_err_hz: 0.0007, U_fknee_hz: 0.0037, U_slope: 1.371, U_slope_err: 0.004,
-    U_wn_level_err_k2_hz: 3.0e-07, U_wn_level_k2_hz: 1.5e-06, analysis_id: 73, test_id: 507}
+    U_wn_level_err_k2_hz: 3.0e-07, U_wn_level_k2_hz: 1.5e-06, analysis_id: 73, load_a_temperature_k: 22.644807750000002,
+    load_average_temperature_k: 21.264653875, load_b_temperature_k: 19.8845, test_id: 507}
   tnoise:
     analysis_ids: [119, 120]
     test_ids: [505, 506]
@@ -2105,7 +2119,9 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.07, Q_fknee_hz: 0.41,
     Q_slope: 0.834, Q_slope_err: 0.0007, Q_wn_level_err_k2_hz: 2.0e-07, Q_wn_level_k2_hz: 1.3e-06,
     U_fknee_err_hz: 0.02, U_fknee_hz: 0.07, U_slope: 0.3585, U_slope_err: 0.0003,
-    U_wn_level_err_k2_hz: 1.0e-07, U_wn_level_k2_hz: 1.1e-06, analysis_id: 41, test_id: 198}
+    U_wn_level_err_k2_hz: 1.0e-07, U_wn_level_k2_hz: 1.1e-06, analysis_id: 41, load_a_temperature_k: 22.744546250000006,
+    load_average_temperature_k: 21.325523125000004, load_b_temperature_k: 19.9065,
+    test_id: 198}
   tnoise:
     analysis_ids: [66, 87]
     test_ids: [150, 151]
@@ -2158,7 +2174,9 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.05, Q_fknee_hz: 0.23,
     Q_slope: 1.598, Q_slope_err: 0.001, Q_wn_level_err_k2_hz: 8.0e-07, Q_wn_level_k2_hz: 2.1e-06,
     U_fknee_err_hz: 0.02, U_fknee_hz: 0.09, U_slope: 1.421, U_slope_err: 0.001, U_wn_level_err_k2_hz: 6.0e-07,
-    U_wn_level_k2_hz: 1.7e-06, analysis_id: 65, test_id: 609}
+    U_wn_level_k2_hz: 1.7e-06, analysis_id: 65, load_a_temperature_k: 22.680353750000002,
+    load_average_temperature_k: 21.290676875000003, load_b_temperature_k: 19.901,
+    test_id: 609}
   tnoise:
     analysis_ids: [67, 68]
     test_ids: [281, 282]
@@ -2312,7 +2330,8 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.03, Q_fknee_hz: 0.09,
     Q_slope: 1.176, Q_slope_err: 0.004, Q_wn_level_err_k2_hz: 5.0e-07, Q_wn_level_k2_hz: 1.5e-06,
     U_fknee_err_hz: 0.03, U_fknee_hz: 0.06, U_slope: 0.576, U_slope_err: 0.006, U_wn_level_err_k2_hz: 4.0e-07,
-    U_wn_level_k2_hz: 1.4e-06, analysis_id: 44, test_id: 166}
+    U_wn_level_k2_hz: 1.4e-06, analysis_id: 44, load_a_temperature_k: 22.6822, load_average_temperature_k: 21.298475000000003,
+    load_b_temperature_k: 19.91475, test_id: 166}
   tnoise:
     analysis_ids: [71, 72]
     test_ids: [146, 147]
@@ -2367,7 +2386,9 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.08, Q_fknee_hz: 0.13,
     Q_slope: 1.41, Q_slope_err: 0.02, Q_wn_level_err_k2_hz: 1.0e-07, Q_wn_level_k2_hz: 9.0e-07,
     U_fknee_err_hz: 0.01, U_fknee_hz: 0.02, U_slope: 1.22, U_slope_err: 0.02, U_wn_level_err_k2_hz: 9.0e-08,
-    U_wn_level_k2_hz: 7.4e-07, analysis_id: 45, test_id: 226}
+    U_wn_level_k2_hz: 7.4e-07, analysis_id: 45, load_a_temperature_k: 22.749677000000002,
+    load_average_temperature_k: 21.336338500000004, load_b_temperature_k: 19.923000000000002,
+    test_id: 226}
   tnoise:
     analysis_ids: [73, 74]
     test_ids: [142, 143]
@@ -2528,7 +2549,8 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.2, Q_fknee_hz: 0.3,
     Q_slope: 0.65, Q_slope_err: 0.02, Q_wn_level_err_k2_hz: 9.0e-07, Q_wn_level_k2_hz: 2.2e-06,
     U_fknee_err_hz: 0.04, U_fknee_hz: 0.04, U_slope: 0.64, U_slope_err: 0.03, U_wn_level_err_k2_hz: 8.0e-07,
-    U_wn_level_k2_hz: 2.1e-06, analysis_id: 48, test_id: 462}
+    U_wn_level_k2_hz: 2.1e-06, analysis_id: 48, load_a_temperature_k: 22.67337675,
+    load_average_temperature_k: 21.285813375, load_b_temperature_k: 19.89825, test_id: 462}
   tnoise:
     analysis_ids: [115, 116]
     test_ids: [466, 467]
@@ -2581,7 +2603,9 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.02, Q_fknee_hz: 0.09,
     Q_slope: 1.322, Q_slope_err: 0.006, Q_wn_level_err_k2_hz: 4.0e-07, Q_wn_level_k2_hz: 1.1e-06,
     U_fknee_err_hz: 0.01, U_fknee_hz: 0.05, U_slope: 1.053, U_slope_err: 0.004, U_wn_level_err_k2_hz: 3.0e-07,
-    U_wn_level_k2_hz: 1.0e-06, analysis_id: 49, test_id: 195}
+    U_wn_level_k2_hz: 1.0e-06, analysis_id: 49, load_a_temperature_k: 22.725092250000003,
+    load_average_temperature_k: 21.310296125, load_b_temperature_k: 19.895500000000002,
+    test_id: 195}
   tnoise:
     analysis_ids: [77, 78]
     test_ids: [138, 139]
@@ -2635,7 +2659,8 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.3, Q_fknee_hz: 1.3,
     Q_slope: 0.78852, Q_slope_err: 3.0e-05, Q_wn_level_err_k2_hz: 5.0e-07, Q_wn_level_k2_hz: 2.9e-06,
     U_fknee_err_hz: 0.2, U_fknee_hz: 0.8, U_slope: 0.63419, U_slope_err: 3.0e-05,
-    U_wn_level_err_k2_hz: 3.0e-07, U_wn_level_k2_hz: 2.0e-06, analysis_id: 67, test_id: 620}
+    U_wn_level_err_k2_hz: 3.0e-07, U_wn_level_k2_hz: 2.0e-06, analysis_id: 67, load_a_temperature_k: 22.060447,
+    load_average_temperature_k: 21.140223499999998, load_b_temperature_k: 20.22, test_id: 620}
   tnoise:
     analysis_ids: [79, 80]
     test_ids: [74, 75]
@@ -2688,7 +2713,9 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.01, Q_fknee_hz: 0.138,
     Q_slope: 1.548, Q_slope_err: 0.003, Q_wn_level_err_k2_hz: 1.0e-07, Q_wn_level_k2_hz: 1.5e-06,
     U_fknee_err_hz: 0.006, U_fknee_hz: 0.113, U_slope: 1.73, U_slope_err: 0.0007,
-    U_wn_level_err_k2_hz: 1.0e-07, U_wn_level_k2_hz: 1.2e-06, analysis_id: 51, test_id: 476}
+    U_wn_level_err_k2_hz: 1.0e-07, U_wn_level_k2_hz: 1.2e-06, analysis_id: 51, load_a_temperature_k: 22.697592250000003,
+    load_average_temperature_k: 21.295171125000003, load_b_temperature_k: 19.89275,
+    test_id: 476}
   tnoise:
     analysis_ids: [126, 127]
     test_ids: [474, 475]
@@ -2957,7 +2984,9 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.01, Q_fknee_hz: 0.025,
     Q_slope: 1.47, Q_slope_err: 0.01, Q_wn_level_err_k2_hz: 2.0e-07, Q_wn_level_k2_hz: 1.5e-06,
     U_fknee_err_hz: 0.003, U_fknee_hz: 0.01, U_slope: 1.033, U_slope_err: 0.006, U_wn_level_err_k2_hz: 2.0e-07,
-    U_wn_level_k2_hz: 1.4e-06, analysis_id: 58, test_id: 583}
+    U_wn_level_k2_hz: 1.4e-06, analysis_id: 58, load_a_temperature_k: 22.203720500000003,
+    load_average_temperature_k: 21.041360250000004, load_b_temperature_k: 19.879,
+    test_id: 583}
   tnoise:
     analysis_ids: [117, 118]
     test_ids: [483, 484]
@@ -3139,7 +3168,8 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.002, Q_fknee_hz: 0.017,
     Q_slope: 2.51, Q_slope_err: 0.01, Q_wn_level_err_k2_hz: 8.0e-07, Q_wn_level_k2_hz: 6.7e-06,
     U_fknee_err_hz: 0.004, U_fknee_hz: 0.033, U_slope: 1.217, U_slope_err: 0.003,
-    U_wn_level_err_k2_hz: 6.0e-07, U_wn_level_k2_hz: 5.1e-06, analysis_id: 68, test_id: 662}
+    U_wn_level_err_k2_hz: 6.0e-07, U_wn_level_k2_hz: 5.1e-06, analysis_id: 68, load_a_temperature_k: 21.23666,
+    load_average_temperature_k: 20.803330000000003, load_b_temperature_k: 20.37, test_id: 662}
   tnoise:
     analysis_ids: [161, 162]
     test_ids: [655, 656]
@@ -3227,7 +3257,8 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.04, Q_fknee_hz: 0.3,
     Q_slope: 1.0512, Q_slope_err: 0.0002, Q_wn_level_err_k2_hz: 5.0e-07, Q_wn_level_k2_hz: 4.2e-06,
     U_fknee_err_hz: 0.6, U_fknee_hz: 2.7, U_slope: 0.9053, U_slope_err: 0.0002, U_wn_level_err_k2_hz: 1.0e-06,
-    U_wn_level_k2_hz: 6.0e-06, analysis_id: 71, test_id: 607}
+    U_wn_level_k2_hz: 6.0e-06, analysis_id: 71, load_a_temperature_k: 21.284800000000004,
+    load_average_temperature_k: 21.232400000000002, load_b_temperature_k: 21.18, test_id: 607}
   tnoise:
     analysis_ids: [163, 144]
     test_ids: [595, 596]
@@ -3314,7 +3345,8 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.7, Q_fknee_hz: 3.0,
     Q_slope: 1.0281, Q_slope_err: 0.0003, Q_wn_level_err_k2_hz: 3.0e-06, Q_wn_level_k2_hz: 1.3e-05,
     U_fknee_err_hz: 2.4, U_fknee_hz: 8.0, U_slope: 0.9752, U_slope_err: 0.0003, U_wn_level_err_k2_hz: 2.0e-06,
-    U_wn_level_k2_hz: 6.0e-06, analysis_id: 72, test_id: 671}
+    U_wn_level_k2_hz: 6.0e-06, analysis_id: 72, load_a_temperature_k: 21.2375, load_average_temperature_k: 20.49875,
+    load_b_temperature_k: 19.759999999999998, test_id: 671}
   tnoise:
     analysis_ids: [164, 165]
     test_ids: [668, 669]
@@ -3397,7 +3429,8 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.2, Q_fknee_hz: 1.7,
     Q_slope: 1.12097, Q_slope_err: 9.0e-05, Q_wn_level_err_k2_hz: 4.0e-07, Q_wn_level_k2_hz: 3.2e-06,
     U_fknee_err_hz: 0.2, U_fknee_hz: 1.5, U_slope: 0.9872, U_slope_err: 0.0001, U_wn_level_err_k2_hz: 3.0e-07,
-    U_wn_level_k2_hz: 2.6e-06, analysis_id: 80, test_id: 681}
+    U_wn_level_k2_hz: 2.6e-06, analysis_id: 80, load_a_temperature_k: 20.619600000000002,
+    load_average_temperature_k: 20.3698, load_b_temperature_k: 20.12, test_id: 681}
   tnoise:
     analysis_ids: [173, 174]
     test_ids: [674, 675]
@@ -3487,7 +3520,8 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.002, Q_fknee_hz: 0.007,
     Q_slope: 0.64, Q_slope_err: 0.002, Q_wn_level_err_k2_hz: 3.0e-05, Q_wn_level_k2_hz: 0.00023,
     U_fknee_err_hz: 0.005, U_fknee_hz: 0.046, U_slope: 1.178, U_slope_err: 0.001,
-    U_wn_level_err_k2_hz: 6.0e-07, U_wn_level_k2_hz: 5.0e-06, analysis_id: 75, test_id: 517}
+    U_wn_level_err_k2_hz: 6.0e-07, U_wn_level_k2_hz: 5.0e-06, analysis_id: 75, load_a_temperature_k: 22.798240000000003,
+    load_average_temperature_k: 21.59912, load_b_temperature_k: 20.4, test_id: 517}
   tnoise:
     analysis_ids: [145, 146]
     test_ids: [520, 521]
@@ -3578,7 +3612,9 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.002, Q_fknee_hz: 0.001,
     Q_slope: 1.33, Q_slope_err: 0.06, Q_wn_level_err_k2_hz: 0.0001, Q_wn_level_k2_hz: 0.0001,
     U_fknee_err_hz: 0.0009, U_fknee_hz: 0.0006, U_slope: 1.94, U_slope_err: 0.04,
-    U_wn_level_err_k2_hz: 4.0e-05, U_wn_level_k2_hz: 5.0e-05, analysis_id: 76, test_id: 594}
+    U_wn_level_err_k2_hz: 4.0e-05, U_wn_level_k2_hz: 5.0e-05, analysis_id: 76, load_a_temperature_k: 21.285220000000002,
+    load_average_temperature_k: 21.207610000000003, load_b_temperature_k: 21.130000000000003,
+    test_id: 594}
   tnoise:
     analysis_ids: [147, 148, 149, 150]
     test_ids: [551, 552, 553, 554]
@@ -3671,7 +3707,8 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.008, Q_fknee_hz: 0.066,
     Q_slope: 3.404, Q_slope_err: 0.006, Q_wn_level_err_k2_hz: 9.0e-07, Q_wn_level_k2_hz: 2.3e-06,
     U_fknee_err_hz: 0.009, U_fknee_hz: 0.069, U_slope: 3.716, U_slope_err: 0.01, U_wn_level_err_k2_hz: 9.0e-07,
-    U_wn_level_k2_hz: 2.1e-06, analysis_id: 77, test_id: 531}
+    U_wn_level_k2_hz: 2.1e-06, analysis_id: 77, load_a_temperature_k: 21.22186, load_average_temperature_k: 20.98093,
+    load_b_temperature_k: 20.740000000000002, test_id: 531}
   tnoise:
     analysis_ids: [151, 152, 153, 154]
     test_ids: [535, 536, 537, 538]
@@ -3762,7 +3799,8 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.004, Q_fknee_hz: 0.011,
     Q_slope: 1.38, Q_slope_err: 0.01, Q_wn_level_err_k2_hz: 1.0e-06, Q_wn_level_k2_hz: 8.0e-06,
     U_fknee_err_hz: 0.01, U_fknee_hz: 0.02, U_slope: 0.93, U_slope_err: 0.009, U_wn_level_err_k2_hz: 5.0e-07,
-    U_wn_level_k2_hz: 3.1e-06, analysis_id: 78, test_id: 523}
+    U_wn_level_k2_hz: 3.1e-06, analysis_id: 78, load_a_temperature_k: 20.906740000000003,
+    load_average_temperature_k: 21.14837, load_b_temperature_k: 21.39, test_id: 523}
   tnoise:
     analysis_ids: [155, 156]
     test_ids: [525, 528]
@@ -3849,7 +3887,9 @@
     I_wn_level_err_k2_hz: 0.0, I_wn_level_k2_hz: 0.0, Q_fknee_err_hz: 0.003, Q_fknee_hz: 0.016,
     Q_slope: 1.057, Q_slope_err: 0.001, Q_wn_level_err_k2_hz: 5.0e-06, Q_wn_level_k2_hz: 2.7e-05,
     U_fknee_err_hz: 0.003, U_fknee_hz: 0.023, U_slope: 1.333, U_slope_err: 0.001,
-    U_wn_level_err_k2_hz: 3.0e-06, U_wn_level_k2_hz: 1.7e-05, analysis_id: 74, test_id: 539}
+    U_wn_level_err_k2_hz: 3.0e-06, U_wn_level_k2_hz: 1.7e-05, analysis_id: 74, load_a_temperature_k: 21.40186,
+    load_average_temperature_k: 21.05093, load_b_temperature_k: 20.700000000000003,
+    test_id: 539}
   tnoise:
     analysis_ids: [157, 158]
     test_ids: [543, 544]
@@ -3857,3 +3897,4 @@
     tnoise_k: 183.162
     values_k: [-152.22, 125.434, 128.157, 130.684, 144.719, 154.498, 183.162, 215.438,
       218.571, 221.982, 226.472, 228.589, 242.448]
+

--- a/src/instrumentdb.jl
+++ b/src/instrumentdb.jl
@@ -1,6 +1,7 @@
 export Horn, Detector, InstrumentDB, BandshapeInfo, SpectrumInfo, NoiseTemperatureInfo
 export InstrumentDB, defaultdbfolder, parsefpdict, parsedetdict
 export sensitivity_tant, t_to_trj, trj_to_t, deltat_to_deltatrj, deltatrj_to_deltat
+export detector, bandpass, spectrum, fknee_hz
 
 import YAML
 import Stripeline
@@ -136,28 +137,29 @@ BandshapeInfo() = BandshapeInfo(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, Float64[], 0, 0
 
 Information about the noise spectrum of the output of a polarimeter.
 
-Field             | Type     | Meaning
-:---------------- |:-------- |:-------------------------------------------------------
-`slope_i`         | Float64  | The slope ($\alpha$) of the 1/f component of the noise in the I signal
-`slope_i_err`     | Float64  | Error associated with the value of `slope_i`
-`slope_q`         | Float64  | Same as `slope_i`, but for the Q signal
-`slope_q_err`     | Float64  | Error associated with the value of `slope_q`
-`slope_u`         | Float64  | Same as `slope_i`, but for the U signal
-`slope_u_err`     | Float64  | Error associated with the value of `slope_u`
-`fknee_i_hz`      | Float64  | Knee frequency of the I signal, in Hz
-`fknee_i_err_hz`  | Float64  | Error associated with the value of `fknee_i_hz`
-`fknee_q_hz`      | Float64  | Knee frequency of the Q signal, in Hz
-`fknee_q_err_hz`  | Float64  | Error associated with the value of `fknee_q_hz`
-`fknee_u_hz`      | Float64  | Knee frequency of the U signal, in Hz
-`fknee_u_err_hz`  | Float64  | Error associated with the value of `fknee_u_hz`
-`wn_i_k2_hz`      | Float64  | White noise level for the I signal, in K^2 Hz
-`wn_i_err_k2_hz`  | Float64  | Error associated with the value of `wn_i_k2_hz`
-`wn_q_k2_hz`      | Float64  | White noise level for the Q signal, in K^2 Hz
-`wn_q_err_k2_hz`  | Float64  | Error associated with the value of `wn_q_k2_hz`
-`wn_u_k2_hz`      | Float64  | White noise level for the U signal, in K^2 Hz
-`wn_u_err_k2_hz`  | Float64  | Error associated with the value of `wn_u_k2_hz`
-`test_id`         | Int      | ID of the unit-level test used to characterize the bandshape
-`analysis_id`     | Int      | ID of the unit-level analysis used to characterize the bandshape
+Field                | Type     | Meaning
+:------------------- |:-------- |:-------------------------------------------------------
+`slope_i`            | Float64  | The slope ($\alpha$) of the 1/f component of the noise in the I signal
+`slope_i_err`        | Float64  | Error associated with the value of `slope_i`
+`slope_q`            | Float64  | Same as `slope_i`, but for the Q signal
+`slope_q_err`        | Float64  | Error associated with the value of `slope_q`
+`slope_u`            | Float64  | Same as `slope_i`, but for the U signal
+`slope_u_err`        | Float64  | Error associated with the value of `slope_u`
+`fknee_i_hz`         | Float64  | Knee frequency of the I signal, in Hz
+`fknee_i_err_hz`     | Float64  | Error associated with the value of `fknee_i_hz`
+`fknee_q_hz`         | Float64  | Knee frequency of the Q signal, in Hz
+`fknee_q_err_hz`     | Float64  | Error associated with the value of `fknee_q_hz`
+`fknee_u_hz`         | Float64  | Knee frequency of the U signal, in Hz
+`fknee_u_err_hz`     | Float64  | Error associated with the value of `fknee_u_hz`
+`wn_i_k2_hz`         | Float64  | White noise level for the I signal, in K^2 Hz
+`wn_i_err_k2_hz`     | Float64  | Error associated with the value of `wn_i_k2_hz`
+`wn_q_k2_hz`         | Float64  | White noise level for the Q signal, in K^2 Hz
+`wn_q_err_k2_hz`     | Float64  | Error associated with the value of `wn_q_k2_hz`
+`wn_u_k2_hz`         | Float64  | White noise level for the U signal, in K^2 Hz
+`wn_u_err_k2_hz`     | Float64  | Error associated with the value of `wn_u_k2_hz`
+`load_temperature_k` | Float64  | System brightness temperature used during the tests (in K)
+`test_id`            | Int      | ID of the unit-level test used to characterize the bandshape
+`analysis_id`        | Int      | ID of the unit-level analysis used to characterize the bandshape
 """
 struct SpectrumInfo
     slope_i::Float64
@@ -178,6 +180,7 @@ struct SpectrumInfo
     wn_i_err_k2_hz::Float64
     wn_q_err_k2_hz::Float64
     wn_u_err_k2_hz::Float64
+    load_temperature_k::Float64
     test_id::Int
     analysis_id::Int
 end
@@ -194,6 +197,7 @@ function Base.show(io::IO, spec::SpectrumInfo)
                 Slope: I = %.4f ± %.4f, Q = %.4f ± %.4f, U = %.4f ± %.4f
                 Knee frequency: I = %.1f ± %.1f mHz, Q = %.1f ± %.1f mHz, U = %.1f ± %.1f mHz
                 White noise: Q = %.1f ± %.1f mK^2 Hz, U = %.1f ± %.1f mK^2 Hz
+                System brightness temperature: %.1f K
                 Test ID: %d
                 Analysis ID: %d""",
             spec.slope_i, spec.slope_i_err,
@@ -204,6 +208,7 @@ function Base.show(io::IO, spec::SpectrumInfo)
             spec.fknee_u_hz * 1e3, spec.fknee_u_err_hz * 1e3,
             spec.wn_q_k2_hz * 1e6, spec.wn_q_err_k2_hz * 1e6,
             spec.wn_u_k2_hz * 1e6, spec.wn_u_err_k2_hz * 1e6,
+            spec.load_temperature_k,
             spec.test_id,
             spec.analysis_id)
     end
@@ -214,7 +219,7 @@ end
 
 Initialize a SpectrumInfo object with all values set to zero.
 """
-SpectrumInfo() = SpectrumInfo(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0)
+SpectrumInfo() = SpectrumInfo(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0)
 
 @doc raw"""
     NoiseTemperatureInfo
@@ -480,6 +485,7 @@ function parsespectrum(specdict::Dict{Any,Any})
         get(specdict, "I_wn_level_err_k2_hz", 0.0),
         get(specdict, "Q_wn_level_err_k2_hz", 0.0),
         get(specdict, "U_wn_level_err_k2_hz", 0.0),
+        get(specdict, "load_average_temperature_k", 20.0),
         get(specdict, "test_id", 0),
         get(specdict, "analysis_id", 0))
 end
@@ -555,6 +561,124 @@ Load the STRIP instrument database from the directory returned by
 [`defaultdbfolder`](@ref). Return an instance of a InstrumentDB object.
 """
 InstrumentDB() = InstrumentDB(defaultdbfolder())
+
+################################################################################
+
+detector(db::InstrumentDB, polid::Integer) = db.detectors[polid]
+detector(db::InstrumentDB, horn_name::AbstractString) = detector(db, db.focalplane[horn_name].polid)
+
+@doc raw"""
+    detector(db::InstrumentDB, polid::Integer) -> Detector
+    detector(db::InstrumentDB, horn_name::AbstractString) -> Detector
+
+Return a [`Detector`](@ref) structure, taken from the instrument database. If
+the form with `polid` is used, `polid` is the progressive number of the
+polarimeter; e.g., for `STRIP02`, `polid == 2`. In the second form, you pass the
+string identifying the horn on the focal plane, e.g., `I0`, `W3`, etc.
+
+```julia
+db = InstrumentDB()
+pol1 = detector(db, 16)   # Get information about STRIP16
+pol2 = detector(db, "V4") # Get information about the detector connected to horn V4
+```
+
+"""
+detector
+
+function bandpass(db::InstrumentDB, polid::Integer)
+    bandinfo = detector(db, polid).bandshape
+    ν = range(bandinfo.lowest_frequency_hz, bandinfo.highest_frequency_hz, length = bandinfo.num_of_frequencies)
+
+    @assert length(ν) == length(bandinfo.bandshape)
+    (ν, bandinfo.bandshape)
+end
+
+bandpass(db::InstrumentDB, horn_name::AbstractString) = bandpass(db, db.focalplane[horn_name].polid)
+
+@doc raw"""
+    bandpass(db::InstrumentDB, polid::Integer) -> Tuple{Array{Float64, 1}, Array{Float64, 1}}
+    bandpass(db::InstrumentDB, horn_name::AbstractString) -> Tuple{Array{Float64, 1}, Array{Float64, 1}}
+
+Return a pair `(ν_hz, B)` containing the bandpass `B` for the horn with the
+specified ID (`polid`) or associated to some horn (`horn_name`). To understand
+how `polid` and `horn_name` work, see the documentation for [`detector`](@ref).
+
+The two elements of the tuple `(ν_hz, B)` are two arrays of the same length
+containing the frequencies (in Hz) and the bandpass response at the same
+frequency (pure number).
+
+```julia
+db = InstrumentDB()
+x, y = bandpass(db, "G2")
+plot(x, y)   # Plot the bandpass
+```
+
+"""
+bandpass
+
+spectrum(db::InstrumentDB, polid::Integer) = detector(db, polid).spectrum
+spectrum(db::InstrumentDB, horn_name::AbstractString) = spectrum(db, db.focalplane[horn_name].polid)
+
+@doc raw"""
+    spectrum(db::InstrumentDB, polid::Integer) -> SpectrumInfo
+    spectrum(db::InstrumentDB, horn_name::AbstractString) -> SpectrumInfo
+
+Return a [`SpectrumInfo`](@ref) object, taken from the instrument database. The
+meaning of the parameters `polid` and `horn_name` is explained in the
+documentation for [`detector`](@ref).
+
+"""
+spectrum
+
+tnoise(db::InstrumentDB, polid::Integer) = detector(db, polid).tnoise
+tnoise(db::InstrumentDB, horn_name::AbstractString) = tnoise(db, db.focalplane[horn_name].polid)
+
+@doc raw"""
+    tnoise(db::InstrumentDB, polid::Integer) -> NoiseTemperatureInfo
+    tnoise(db::InstrumentDB, horn_name::AbstractString) -> NoiseTemperatureInfo
+
+Return a [`NoiseTemperatureInfo`](@ref) object, taken from the instrument
+database. The meaning of the parameters `polid` and `horn_name` is explained in
+the documentation for [`detector`](@ref).
+
+"""
+tnoise
+
+function fknee_hz(db::InstrumentDB, polid::Integer; tsys_k = missing)
+    specinfo = spectrum(db, polid)
+
+    tsys_k === missing && return (specinfo.fknee_i_hz, specinfo.fknee_q_hz, specinfo.fknee_u_hz)
+
+    # Correct the value of fknee depending on the ratio between the system
+    # temperature now and the temperature used during the characterization of the
+    # polarimeter
+
+    (α_i, α_q, α_u) = (specinfo.slope_i, specinfo.slope_q, specinfo.slope_u)
+    load_ratio = specinfo.load_temperature_k / tsys_k
+
+    (specinfo.fknee_i_hz * load_ratio^(1 / α_i),
+        specinfo.fknee_q_hz * load_ratio^(1 / α_q),
+        specinfo.fknee_u_hz * load_ratio^(1 / α_u),)
+end
+
+fknee_hz(db::InstrumentDB, horn_name::AbstractString; tsys_k = missing) = fknee_hz(db, db.focalplane[horn_name].polid; tsys_k = tsys_k)
+
+@doc raw"""
+    fknee_hz(db::InstrumentDB, polid::Integer; tsys_k = missing) -> Tuple{Float64, Float64, Float64}
+    fknee_hz(db::InstrumentDB, horn_name::AbstractString; tsys_k = missing) -> Tuple{Float64, Float64, Float64}
+
+Return the knee frequency for the selected detector, taken from the instrument
+database. The meaning of the parameters `polid` and `horn_name` is explained in
+the documentation for [`detector`](@ref).
+
+If `tsys_k` is specified, the system temperature is rescaled to the desired
+temperature of the load feeding the polarimeter, so that the 1/f component of
+the noise remains unchanged but the white noise plateau raises/lowers by an
+appropriate amount. Otherwise, the function returns the raw frequency taken from
+the instrument database.
+
+"""
+fknee_hz
 
 ################################################################################
 

--- a/src/instrumentdb.jl
+++ b/src/instrumentdb.jl
@@ -1,7 +1,7 @@
 export Horn, Detector, InstrumentDB, BandshapeInfo, SpectrumInfo, NoiseTemperatureInfo
 export InstrumentDB, defaultdbfolder, parsefpdict, parsedetdict
 export sensitivity_tant, t_to_trj, trj_to_t, deltat_to_deltatrj, deltatrj_to_deltat
-export detector, bandpass, spectrum, fknee_hz
+export detector, bandpass, spectrum, fknee_hz, tnoise
 
 import YAML
 import Stripeline

--- a/test/instrumentdb_tests.jl
+++ b/test/instrumentdb_tests.jl
@@ -14,6 +14,27 @@ defaultdb = Sl.InstrumentDB()
 @test sort(collect(keys(defaultdb.focalplane))) == sort(collect(keys(db.focalplane)))
 @test sort(collect(keys(defaultdb.detectors))) == sort(collect(keys(db.detectors)))
 
+# Check the high-level API
+
+@test Sl.detector(defaultdb, "I0") != nothing
+@test Sl.detector(defaultdb, 2) != nothing
+
+@test Sl.spectrum(defaultdb, 2) != nothing
+@test Sl.spectrum(defaultdb, "I0") != nothing
+
+@test Sl.tnoise(defaultdb, 2) != nothing
+@test Sl.tnoise(defaultdb, "I0") != nothing
+
+x, y = Sl.bandpass(defaultdb, "I0")
+@test length(x) > 0
+@test length(x) == length(y)
+
+f1_i, f1_q, f1_u = Sl.fknee_hz(defaultdb, 10)
+f2_i, f2_q, f2_u = Sl.fknee_hz(defaultdb, 10, tsys_k = 1000.0)
+
+@test f2_q < f1_q
+@test f2_u < f1_u
+
 # Just a few basic checks, to verify that the function does not crash
 (sensitivity, num) = Sl.sensitivity_tant(defaultdb, 10.0)
 @test sensitivity > 0.0


### PR DESCRIPTION
Accessing the instrument database is complex, because of the many levels of redirection. This PR implements a number of functions that should make life easier for people that need to access it. Here is a list of the new functions:

- `detector` returns a `Detector` object, given either a polarimeter number or a string identifying a horn (e.g., `I0`)
- `bandpass` returns a pair of arrays containing the shape of the band response for either a polarimeter or a horn
- `fknee_hz` returns the knee frequency, possibly with a correction for the effective system brightness temperature
- `spectrum` returns a `SpectrumInfo` object
- `tnoise` returns a `NoiseTemperatureInfo` object

In order to support the correction in `fknee_hz` for tsys, the instrument database has been updated with the effective brightness temperature of the load during the 1/f tests. Because of the sloppy way these tests were performed in Bicocca, not every test has this information; if the datum is missing, `fknee_hz` assumes that the brightness temperature of the loads were 20 K.