### PR TITLE
fix num_of_frequencies and highest_frequency_hz for Wband in DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add functions to simulate ADCs [#24](https://github.com/lspestrip/Stripeline.jl/pull/24)
 - Add a high-level API for accessing the instrument database [#30](https://github.com/lspestrip/Stripeline.jl/pull/30)
+- Fix bandshapes for W-band polarimeters [#32](https://github.com/lspestrip/Stripeline.jl/pull/32)
 
 # Version 0.4
 

--- a/instrumentdb/strip_detectors.yaml
+++ b/instrumentdb/strip_detectors.yaml
@@ -3066,9 +3066,9 @@
     bandwidth_hz: 9003272275
     center_frequency_err_hz: 407779571
     center_frequency_hz: 95171361635
-    highest_frequency_hz: 109699996948
+    highest_frequency_hz: 109500000000
     lowest_frequency_hz: 80000000000
-    num_of_frequencies: 298
+    num_of_frequencies: 296
     test_id: [644, 645]
   id: 71
   name: STRIP71
@@ -3158,9 +3158,9 @@
     bandwidth_hz: 7787867912
     center_frequency_err_hz: 612100078
     center_frequency_hz: 96253106304
-    highest_frequency_hz: 109699996948
+    highest_frequency_hz: 109500000000
     lowest_frequency_hz: 80000000000
-    num_of_frequencies: 298
+    num_of_frequencies: 296
     test_id: [653, 654]
   id: 72
   name: STRIP72
@@ -3335,9 +3335,9 @@
     bandwidth_hz: 4090938837
     center_frequency_err_hz: 935338489
     center_frequency_hz: 95534388036
-    highest_frequency_hz: 109699996948
+    highest_frequency_hz: 109500000000
     lowest_frequency_hz: 80000000000
-    num_of_frequencies: 298
+    num_of_frequencies: 296
     test_id: [666, 667]
   id: 74
   name: STRIP74
@@ -3419,9 +3419,9 @@
     bandwidth_hz: 5285643346
     center_frequency_err_hz: 300795625
     center_frequency_hz: 95685445884
-    highest_frequency_hz: 109699996948
+    highest_frequency_hz: 109500000000
     lowest_frequency_hz: 80000000000
-    num_of_frequencies: 298
+    num_of_frequencies: 296
     test_id: [672, 673]
   id: 75
   name: STRIP75
@@ -3510,9 +3510,9 @@
     bandwidth_hz: 6570119393
     center_frequency_err_hz: 430697488
     center_frequency_hz: 97516890416
-    highest_frequency_hz: 109600000000
+    highest_frequency_hz: 109500000000
     lowest_frequency_hz: 80000000000
-    num_of_frequencies: 297
+    num_of_frequencies: 296
     test_id: [518, 519]
   id: 76
   name: STRIP76
@@ -3602,9 +3602,9 @@
     bandwidth_hz: 8117989796
     center_frequency_err_hz: 396232645
     center_frequency_hz: 98499570291
-    highest_frequency_hz: 109600000000
+    highest_frequency_hz: 109500000000
     lowest_frequency_hz: 80000000000
-    num_of_frequencies: 297
+    num_of_frequencies: 296
     test_id: [548, 549]
   id: 77
   name: STRIP77
@@ -3789,9 +3789,9 @@
     bandwidth_hz: 8642675750
     center_frequency_err_hz: 429829028
     center_frequency_hz: 99767648702
-    highest_frequency_hz: 109700000000
+    highest_frequency_hz: 109500000000
     lowest_frequency_hz: 80000000000
-    num_of_frequencies: 298
+    num_of_frequencies: 296
     test_id: [529, 530]
   id: 81
   name: STRIP81


### PR DESCRIPTION
Some of RF tests for W-band polarimeters were done without fixing the higher frequency limit.
As a result, some of the tests finished at 109.5 GHz, some at 109.6, some at 109.7.
For sake of semplicity, in order to calculate the median bandshape we decided to cut all the tests at 109.5 GHz, eventually dropping the last 1-2 points. 
When updating the database (about 2 months ago) I forgot to change the `highest_frequency_hz ` and the 
`num_of_frequencies` parameters in the DB. 
This commit fix it.
