### PR TITLE
Fix oof slope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # HEAD
 
+- Make the 1/f slope always in the range 0..2 [#34](https://github.com/lspestrip/Stripeline.jl/pull/34)
+
 # Version 0.4.3
 
 - Add functions to simulate ADCs [#24](https://github.com/lspestrip/Stripeline.jl/pull/24)

--- a/src/DBforsimulation.jl
+++ b/src/DBforsimulation.jl
@@ -48,10 +48,8 @@ function get_info_from_DB(db, horns, Stokes)
                 print("Choose a Stokes parameter: Q or U") 
                 break
             end
-                push!(measured_fknees, fknee)
-                #correct for too high slopes, since noise generator works till slope=2
-                if slope > 2 slope = 2.0 end 
-                push!(measured_slopes, slope)
+            push!(measured_fknees, fknee)
+            push!(measured_slopes, clamp(slope, 0.0, 2.0))
 
         end
     end

--- a/src/noisegeneration.jl
+++ b/src/noisegeneration.jl
@@ -131,7 +131,7 @@ function  generate_noise_mpi(chunks, baselines_per_process, baseline_length_s, t
         noise = Array{Float64}(undef, baselines_per_process[rank+1]*baseline_length_s*fsamp_hz)    
         
         if  0 <= rank < total_number_of_polarimeters  #if first "total_number_of_polarimeters" ranks
-            rng = CorrNoise.OofRNG(Random.MersenneTwister(seeds[pol_number]), slope[pol_number], 1.15e-5, fknee_hz[pol_number], fsamp_hz)
+            rng = CorrNoise.OofRNG(Random.MersenneTwister(seeds[pol_number]), -abs(slope[pol_number]), 1.15e-5, fknee_hz[pol_number], fsamp_hz)
             samples_per_pol = total_time*fsamp_hz
             pol_noise = Float64[CorrNoise.randoof(rng) * σ_k[pol_number] for i in 1:(samples_per_pol)]
         end
@@ -193,7 +193,7 @@ function  generate_noise_mpi(chunks, baselines_per_process, baseline_length_s, t
             previous_detector = chunks[1][1].pol_number
             noise = Float64[]  #noise rank 0
 
-            rng = CorrNoise.OofRNG(Random.MersenneTwister(seeds[1]), slope[1], 1.15e-5, fknee_hz[1], fsamp_hz)
+            rng = CorrNoise.OofRNG(Random.MersenneTwister(seeds[1]), -abs(slope[1]), 1.15e-5, fknee_hz[1], fsamp_hz)
 
             for i in 1:length(chunks)   #loop on ranks
                 num_noise_samples = baselines_per_process[i]*baseline_length_s*fsamp_hz
@@ -202,7 +202,7 @@ function  generate_noise_mpi(chunks, baselines_per_process, baseline_length_s, t
                     cur_detector = chunks[i][j].pol_number
 
                     if cur_detector != previous_detector  #if new detector generate new noise
-                        rng = CorrNoise.OofRNG(Random.MersenneTwister(seeds[cur_detector]), slope[cur_detector], 1.15e-5, fknee_hz[cur_detector], fsamp_hz)
+                        rng = CorrNoise.OofRNG(Random.MersenneTwister(seeds[cur_detector]), -abs(slope[cur_detector]), 1.15e-5, fknee_hz[cur_detector], fsamp_hz)
                     end
                     cur_num_noise_samples = chunks[i][j].num_of_elements*baseline_length_s*fsamp_hz
                     cur_noise = Float64[CorrNoise.randoof(rng) * σ_k[cur_detector] for i in 1:(cur_num_noise_samples)]


### PR DESCRIPTION
two commits about fixing how oof slopes taken from the DB are managed in Stripeline.
The first just assures that the slope value given in input to the noise generator is always negative.
The second correct for too high slopes (>2): since the noise generator we currently use only works up to slope=2, we put all the slopes above the limit manually equal to 2. 