### PR TITLE
Restructure the interface to map-maker and noise generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 - (**Breaking change**) Turn `rank` and `comm` parameters into
   keywords for `generate_noise_mpi`
+  [#39](https://github.com/lspestrip/Stripeline.jl/pull/39)
 - (**Breaking change**) Use `nothing` instead of `missing` for MPI
   communicators
+  [#39](https://github.com/lspestrip/Stripeline.jl/pull/39)
 - Ensure that `generate_noise_mpi` produces different seeds for each
   polarimeter
+  [#39](https://github.com/lspestrip/Stripeline.jl/pull/39)
 - (**Breaking change**) Make `destripe` return a `DestripingResults`
   structure instead of a tuple
+  [#39](https://github.com/lspestrip/Stripeline.jl/pull/39)
 - Remove the dependency on `Quaternions.jl` [#38](https://github.com/lspestrip/Stripeline.jl/pull/38)
 - Update the instrument database with the number of the polarizer for each horn [#37](https://github.com/lspestrip/Stripeline.jl/pull/37)
 - Make the 1/f slope always in the range 0..2 [#34](https://github.com/lspestrip/Stripeline.jl/pull/34)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # HEAD
 
+- (**Breaking change**) Turn `rank` and `comm` parameters into
+  keywords for `generate_noise_mpi`
+- (**Breaking change**) Use `nothing` instead of `missing` for MPI
+  communicators
+- Ensure that `generate_noise_mpi` produces different seeds for each
+  polarimeter
+- (**Breaking change**) Make `destripe` return a `DestripingResults`
+  structure instead of a tuple
 - Remove the dependency on `Quaternions.jl` [#38](https://github.com/lspestrip/Stripeline.jl/pull/38)
 - Update the instrument database with the number of the polarizer for each horn [#37](https://github.com/lspestrip/Stripeline.jl/pull/37)
 - Make the 1/f slope always in the range 0..2 [#34](https://github.com/lspestrip/Stripeline.jl/pull/34)

--- a/src/mapmaker.jl
+++ b/src/mapmaker.jl
@@ -1,11 +1,11 @@
-export data_properties_struct, get_data_properties, tod2map_mpi, baseline2map_mpi, destripe, baselines_covmat
+export TodNoiseProperties, get_data_properties, tod2map_mpi, baseline2map_mpi, destripe, baselines_covmat
 
 using LinearAlgebra
 
 try
     import MPI
 catch
-end 
+end
 
 @doc raw"""
 This structure holds a number of parameters relative to the noise level and
@@ -14,46 +14,44 @@ the 1/f baselines measured or simulated for a certain polarimeter.
 Field               | Type           | Meaning
 :-----------------  |:-------------- |:----------------------------------------------------------------------------------
 `pol_number`        | Int            | ID number of the polarimeter
-`σ`                 | Float          | σ of white noise 
+`sigma`             | Float          | sigma of white noise
 `num_of_samples`    | Int            | total number of samples
-`num_of_baselines`  | Int            | total number of 1/f baselines in the measured or simulated TOD for this polarimeter
 `baselines_lengths` | Array{Int}     | Array containing the length of each 1/f baseline for this polarimeter
 
 # Example
-data_properties(1, 0.002463, 500, 5, [100, 100, 100, 100, 100, 100]) 
+data_properties(1, 0.002463, 500, 5, [100, 100, 100, 100, 100, 100])
 
-says that we have 5 baselines simulated for polarimeter number 1 (in this case polarimeter STRIP31, with σ = 0.002463), each of length 100 samples.
+says that we have 5 baselines simulated for polarimeter number 1 (in this case polarimeter STRIP31, with sigma = 0.002463), each of length 100 samples.
 """
-struct data_properties_struct
+struct TodNoiseProperties
     polarimeter::Int
-    σ::Float64
+    sigma::Float64
     number_of_samples::Int
-    number_of_baselines::Int
     baselines_lengths::Array{Int}
 end
 
 
 @doc raw"""
-    function get_data_properties(detector_number, σ_k, num_of_baselines, num_of_samples) -> data_properties
-    
+    function get_data_properties(detector_number, sigma_k, num_of_baselines, num_of_samples) -> data_properties
+
 This function can be used to build the object `data properties` needed for desriping and calculation of baselines_covmat.
 
 It requires in input 4 arrays containing:
 - the ID number of the polarimeters that the current rank will simulate
-- the white noise σ for each polarimeter that the current rank will simulate
+- the white noise sigma for each polarimeter that the current rank will simulate
 - the number of 1/f baselines for each polarimeter that the current rank will simulate
 - the total number of samples for each polarimeter that the current rank will simulate
 
 N.B. the ID numbers, the number of 1/f baselines and the total number of samples can be obtained using the function `get_chunk_properties`.
 
-It returns an array of `data_properties_struct`, of length equal to the number of polarimeters simulated by current rank.
+It returns an array of `TodNoiseProperties`, of length equal to the number of polarimeters simulated by current rank.
 
 """
-function get_data_properties(detector_number, σ_k, num_of_baselines, num_of_samples)
-    data_properties  = Array{data_properties_struct}(undef, length(detector_number))
+function get_data_properties(detector_number, sigma_k, num_of_baselines, num_of_samples)
+    data_properties  = Array{TodNoiseProperties}(undef, length(detector_number))
     for i in 1:length(detector_number)
-        baselines_lengths  = repeat([Int64(num_of_samples[i]/num_of_baselines[i])], num_of_baselines[i])  #we suppose baselines of equal lengths
-        data_properties[i]  = data_properties_struct(detector_number[i], σ_k[detector_number[i]], num_of_samples[i], num_of_baselines[i], baselines_lengths)
+        baselines_lengths  = repeat([Int64(num_of_samples[i] / num_of_baselines[i])], num_of_baselines[i])  #we suppose baselines of equal lengths
+        data_properties[i]  = TodNoiseProperties(detector_number[i], sigma_k[detector_number[i]], num_of_samples[i], baselines_lengths)
     end
     data_properties
 end
@@ -74,8 +72,8 @@ This is a MPI based function: each MPI process computes a map from its
 available data.  All partial maps are then combined together with MPI.allreduce.
 The function returns an array containing the binned map.
 
-If Array of structures `data_properties_struct`is passed to the function, the output binned map will be a weighted binned map.
-Each sample will be weighted according to the inverse white noise variance σ^2 of the corrisponding polarimeter.
+If Array of structures `TodNoiseProperties`is passed to the function, the output binned map will be a weighted binned map.
+Each sample will be weighted according to the inverse white noise variance sigma^2 of the corrisponding polarimeter.
 In this way, the less noisy polarimeters will count more in the estimation of the map.
 
 # Requirements
@@ -85,14 +83,14 @@ In this way, the less noisy polarimeters will count more in the estimation of th
 tod2map_mpi
 
 
-function tod2map_mpi(pix_idx, tod, num_of_pixels, comm; unseen = NaN)   
+function tod2map_mpi(pix_idx, tod, num_of_pixels, comm; unseen = NaN)
     T = eltype(tod)
     N = eltype(pix_idx)
-    
+
     partial_map = zeros(T, num_of_pixels)
     partial_hits = zeros(N, num_of_pixels)
     binned_map = zeros(T, num_of_pixels)
-    hits = zeros(N, num_of_pixels )
+    hits = zeros(N, num_of_pixels)
 
     for i in eachindex(pix_idx)
         partial_map[pix_idx[i]] += tod[i]
@@ -118,25 +116,25 @@ function tod2map_mpi(pix_idx, tod, num_of_pixels, comm; unseen = NaN)
     binned_map
 end
 
-function tod2map_mpi(pix_idx, tod, num_of_pixels, data_properties, comm; unseen = NaN)   
+function tod2map_mpi(pix_idx, tod, num_of_pixels, data_properties, comm; unseen = NaN)
     T = eltype(tod)
-    
+
     partial_map = zeros(T, num_of_pixels)
     partial_hits = zeros(T, num_of_pixels)
     binned_map = zeros(T, num_of_pixels)
-    hits = zeros(T, num_of_pixels )
+    hits = zeros(T, num_of_pixels)
 
     start_idx = 1
 
     for j in eachindex(data_properties)                 #loop on detectors
-        end_idx = start_idx + data_properties[j].number_of_samples-1
-        for i in start_idx:end_idx             #loop on samples 
-            partial_map[pix_idx[i]] += tod[i] * 1/(data_properties[j].σ)^2
-            partial_hits[pix_idx[i]] += 1/(data_properties[j].σ)^2
+        end_idx = start_idx + data_properties[j].number_of_samples - 1
+        for i in start_idx:end_idx             #loop on samples
+            partial_map[pix_idx[i]] += tod[i] * 1 / (data_properties[j].sigma)^2
+            partial_hits[pix_idx[i]] += 1 / (data_properties[j].sigma)^2
         end
         start_idx += data_properties[j].number_of_samples
     end
-    
+
     if(!ismissing(comm))
         binned_map = MPI.allreduce(partial_map, MPI.SUM, comm)
         hits = MPI.allreduce(partial_hits, MPI.SUM, comm)
@@ -165,8 +163,8 @@ available data.  All partial maps are then combined together with
 MPI.allreduce.
 The function returns an array containing the binned map.
 
-If Array of structures `data_properties_struct`is passed to the function (instead of `baseline_lengths`) the output binned map will be a weighted binned map.
-Each sample will be weighted according to the inverse white noise variance σ^2 of the corrisponding polarimeter.
+If Array of structures `TodNoiseProperties`is passed to the function (instead of `baseline_lengths`) the output binned map will be a weighted binned map.
+Each sample will be weighted according to the inverse white noise variance sigma^2 of the corrisponding polarimeter.
 In this way, the less noisy polarimeters will count more in the estimation of the map.
 
 # Requirements
@@ -177,33 +175,33 @@ baseline2map_mpi
 
 
 function baseline2map_mpi(pix_idx, baselines, baseline_lengths, num_of_pixels, comm;
-                          unseen=NaN)
-    
+                          unseen = NaN)
+
     T = eltype(baselines)
     N = eltype(pix_idx)
-    
+
     partial_map = zeros(T, num_of_pixels)
     partial_hits = zeros(N, num_of_pixels)
     noise_map = zeros(T, num_of_pixels)
     hits = zeros(N, num_of_pixels)
 
     startidx = 1
-    
+
     for i in eachindex(baseline_lengths)
-        endidx = baseline_lengths[i] + startidx - 1        
-        
+        endidx = baseline_lengths[i] + startidx - 1
+
         for j in startidx:endidx
             partial_map[pix_idx[j]] += baselines[i]
             partial_hits[pix_idx[j]] += 1
         end
         startidx += baseline_lengths[i]
-    end 
-    
+    end
+
     if(!ismissing(comm))
         noise_map = MPI.allreduce(partial_map, MPI.SUM, comm)
         hits = MPI.allreduce(partial_hits, MPI.SUM, comm)
-    else 
-        
+    else
+
         noise_map .= partial_map
         hits .= partial_hits
     end
@@ -214,41 +212,41 @@ function baseline2map_mpi(pix_idx, baselines, baseline_lengths, num_of_pixels, c
         else
             noise_map[i] = unseen
         end
-    end 
-    
+    end
+
     noise_map
 end
 
-function baseline2map_mpi(pix_idx, baselines, num_of_pixels, data_properties, num_of_baselines, comm; unseen=NaN)
-    
+function baseline2map_mpi(pix_idx, baselines, num_of_pixels, data_properties, num_of_baselines, comm; unseen = NaN)
+
     T = eltype(baselines)
-    
+
     partial_map = zeros(T, num_of_pixels)
     partial_hits = zeros(T, num_of_pixels)
     noise_map = zeros(T, num_of_pixels)
     hits = zeros(T, num_of_pixels)
 
     startidx = 1
-    baseline_idx = 1 
+    baseline_idx = 1
 
     for l in eachindex(data_properties)  #loop on detectors
         for i in eachindex(data_properties[l].baselines_lengths)
-            endidx = data_properties[l].baselines_lengths[i] + startidx - 1        
-        
+            endidx = data_properties[l].baselines_lengths[i] + startidx - 1
+
             for j in startidx:endidx
-                partial_map[pix_idx[j]] += baselines[baseline_idx] * 1/(data_properties[l].σ)^2
-                partial_hits[pix_idx[j]] += 1/(data_properties[l].σ)^2
+                partial_map[pix_idx[j]] += baselines[baseline_idx] * 1 / (data_properties[l].sigma)^2
+                partial_hits[pix_idx[j]] += 1 / (data_properties[l].sigma)^2
             end
             startidx += data_properties[l].baselines_lengths[i]
             baseline_idx += 1
-        end 
+        end
     end
 
     if(!ismissing(comm))
         noise_map = MPI.allreduce(partial_map, MPI.SUM, comm)
         hits = MPI.allreduce(partial_hits, MPI.SUM, comm)
-    else 
-        
+    else
+
         noise_map .= partial_map
         hits .= partial_hits
     end
@@ -259,72 +257,70 @@ function baseline2map_mpi(pix_idx, baselines, num_of_pixels, data_properties, nu
         else
             noise_map[i] = unseen
         end
-    end 
-    
+    end
+
     noise_map
 end
 
 
 
-function applyz_and_sum(pix_idx, tod, num_of_pixels, data_properties, num_of_baselines, comm; unseen=NaN)
+function applyz_and_sum(pix_idx, tod, num_of_pixels, data_properties, num_of_baselines, comm; unseen = NaN)
 
     @assert length(tod) == length(pix_idx)
-        
+
     baselines_sum = zeros(eltype(tod), num_of_baselines)
 
-    binned_map = tod2map_mpi(
-        pix_idx, 
-        tod, 
-        num_of_pixels, 
-        data_properties, 
-        comm, 
-        unseen=unseen)
+    binned_map = tod2map_mpi(pix_idx,
+        tod,
+        num_of_pixels,
+        data_properties,
+        comm,
+        unseen = unseen)
 
     baseline_idx = 1
     startidx = 1
     for l in eachindex(data_properties)  #loop on detectors
-      
+
         for i in eachindex(data_properties[l].baselines_lengths)
             endidx = data_properties[l].baselines_lengths[i] + startidx - 1
 
             for j in startidx:endidx
-                baselines_sum[baseline_idx] += (tod[j] - binned_map[pix_idx[j]]) * 1/(data_properties[l].σ)^2
+                baselines_sum[baseline_idx] += (tod[j] - binned_map[pix_idx[j]]) * 1 / (data_properties[l].sigma)^2
             end
 
             startidx += data_properties[l].baselines_lengths[i]
             baseline_idx += 1
         end
     end
-    
+
     baselines_sum
 end
 
 
-function applya(baselines, pix_idx, num_of_baselines, num_of_pixels, data_properties, comm; unseen=NaN)
+function applya(baselines, pix_idx, num_of_baselines, num_of_pixels, data_properties, comm; unseen = NaN)
     @assert length(baselines) == num_of_baselines
-    
+
     baselines_sum = zeros(eltype(baselines), num_of_baselines)
     total_sum = zero(eltype(baselines))
 
-    binned_map = baseline2map_mpi(
-        pix_idx, 
-        baselines, 
-        num_of_pixels, 
-        data_properties, 
-        num_of_baselines, 
+    binned_map = baseline2map_mpi(pix_idx,
+        baselines,
+        num_of_pixels,
+        data_properties,
+        num_of_baselines,
         comm;
-        unseen=unseen)
+        unseen = unseen)
 
     startidx = 1
     baseline_idx = 1
 
     for l in eachindex(data_properties)
-      
+
         for i in eachindex(data_properties[l].baselines_lengths)
             endidx = data_properties[l].baselines_lengths[i] + startidx - 1
-        
+
             for j in startidx:endidx
-                baselines_sum[baseline_idx] += (baselines[baseline_idx] - binned_map[pix_idx[j]]) * 1/(data_properties[l].σ)^2
+                baselines_sum[baseline_idx] += (baselines[baseline_idx] - binned_map[pix_idx[j]]) * 1 / (data_properties[l].sigma)^2
             end
 
             startidx += data_properties[l].baselines_lengths[i]
@@ -334,13 +330,13 @@ function applya(baselines, pix_idx, num_of_baselines, num_of_pixels, data_proper
 
     #needed to assure that sum(baselines)==0
 
-    if(!ismissing(comm))   
+    if(!ismissing(comm))
         total_sum = MPI.allreduce([sum(baselines)], MPI.SUM, comm)[1]
     else
         total_sum = sum(baselines)
     end
 
-    baselines_sum .+= total_sum 
+    baselines_sum .+= total_sum
 end
 
 
@@ -362,21 +358,21 @@ end
 
 
 function conj_grad(baselines_sum, pix_idx, tod,
-                   num_of_pixels, data_properties, 
-                   num_of_baselines, rank, comm; 
-                   threshold = 1e-9, max_iter=10000)
+                   num_of_pixels, data_properties,
+                   num_of_baselines, rank, comm;
+                   threshold = 1e-9, max_iter = 10000)
 
     T = eltype(tod)
     N = eltype(pix_idx)
-    
+
     baselines = Array{T}(undef, num_of_baselines)
     r = Array{T}(undef, num_of_baselines)
     r_next = Array{T}(undef, num_of_baselines)
     p = Array{T}(undef, num_of_baselines)
-    Ap = Array{T}(undef,num_of_baselines)
-    
-     
-    baselines .= 0    #starting baselines 
+    Ap = Array{T}(undef, num_of_baselines)
+
+
+    baselines .= 0    #starting baselines
     k = zero(N)       #number of iterations
     convergence_parameter = zero(T)
     rdotr = zero(T)
@@ -387,56 +383,49 @@ function conj_grad(baselines_sum, pix_idx, tod,
     best_k = zero(N)
 
     r = baselines_sum - applya(baselines, pix_idx, num_of_baselines, num_of_pixels, data_properties, comm)  #residual
-    p .= r  
+    p .= r
     rdotr = mpi_dot_prod(r, r, comm)
     best_convergence_parameter = sqrt(rdotr)
 
-    if(rdotr == 0)
-        return best_baselines
-    end
+    rdotr == 0 && return best_baselines
 
-
-    while true        
-
-        Ap =  applya(p, pix_idx,  num_of_baselines, num_of_pixels, data_properties, comm)
+    while true
+        Ap = applya(p, pix_idx,  num_of_baselines, num_of_pixels, data_properties, comm)
 
         rdotr = mpi_dot_prod(r, r, comm)
         pdotAp = mpi_dot_prod(p, Ap, comm)
 
         alpha = rdotr / pdotAp
-        @. baselines += alpha * p  
+        @. baselines += alpha * p
         @. r_next = r - alpha * Ap
-        
+
         rdotr_next = mpi_dot_prod(r_next, r_next, comm)
-        
+
         convergence_parameter = sqrt(rdotr_next)
-                
+
         if (convergence_parameter < best_convergence_parameter)
             best_convergence_parameter = convergence_parameter
             best_baselines .= baselines
             best_k = k
         end
 
-        if convergence_parameter < threshold  break end
-        if k  > max_iter   break end
-        
-        beta = rdotr_next/rdotr
-        
+        (convergence_parameter < threshold) || (k > max_iter) && break
+
+        beta = rdotr_next / rdotr
+
         @. p = r_next + beta * p
         r .= r_next
         k += 1
     end
 
-    return best_baselines
+    best_baselines
 end
 
 
-function destriped_map(baselines, pix_idx, tod, data_properties, num_of_pixels, num_of_baselines, comm; unseen=NaN)
+function destriped_map(baselines, pix_idx, tod, data_properties, num_of_pixels, num_of_baselines, comm; unseen = NaN)
     @assert length(tod) == length(pix_idx)
     tod2map_mpi(pix_idx, tod, num_of_pixels, data_properties, comm) - baseline2map_mpi(pix_idx, baselines, num_of_pixels, data_properties, num_of_baselines, comm)
 end
-
-
 
 
 @doc raw"""
@@ -455,8 +444,8 @@ The parameters passed to the function have the following meaning:
 - `num_of_pixels`: the number of pixels in the map to be
    produced. This is used as an upper limit for the values in `pix_idx`
 
-- `data_properties`: an array of structures `data_properties_struct`, 
-   holding information on each simulated polarimeter noise level, 
+- `data_properties`: an array of structures `TodNoiseProperties`,
+   holding information on each simulated polarimeter noise level,
    number and length of 1/f baselines and total number of samples.
    It can be obtained by using function `get_data_properties`.
 
@@ -490,52 +479,47 @@ this is the configuration that will be returned to the caller.
 - If you are not using MPI, pass `missing` to the `comm` parameter.
 """
 function destripe(pix_idx, tod, num_of_pixels, data_properties, rank, comm;
-                 threshold = 1e-9, max_iter = 10000, unseen=NaN)
+                 threshold = 1e-9, max_iter = 10000, unseen = NaN)
 
     num_of_baselines = 0
-    for i in 1:length(data_properties) num_of_baselines  += data_properties[i].number_of_baselines end
+    for i in 1:length(data_properties)
+        num_of_baselines += length(data_properties[i].baselines_lengths)
+    end
 
-    baselines_sum = applyz_and_sum(
-            pix_idx, 
+    baselines_sum = applyz_and_sum(pix_idx,
             tod,
-            num_of_pixels, 
-            data_properties, 
-            num_of_baselines, 
-            comm, 
-            unseen=unseen)
+            num_of_pixels,
+            data_properties,
+            num_of_baselines,
+            comm,
+            unseen = unseen)
 
-    baselines = conj_grad(
-            baselines_sum, 
-            pix_idx, 
-            tod, 
-            num_of_pixels, 
-            data_properties, 
-            num_of_baselines, 
-            rank, 
-            comm; 
-            threshold = threshold, 
+    baselines = conj_grad(baselines_sum,
+            pix_idx,
+            tod,
+            num_of_pixels,
+            data_properties,
+            num_of_baselines,
+            rank,
+            comm;
+            threshold = threshold,
             max_iter = max_iter)
 
     # once we have an estimate of the baselines, we can build the destriped map
-    destr_map = destriped_map(
-            baselines,
-            pix_idx, 
-            tod, 
-            data_properties, 
+    destr_map = destriped_map(baselines,
+            pix_idx,
+            tod,
+            data_properties,
             num_of_pixels,
-            num_of_baselines, 
-            comm, 
-            unseen=unseen)
+            num_of_baselines,
+            comm,
+            unseen = unseen)
 
     #check that sum(baselines) = 0
-    if(!ismissing(comm))   
+    if !ismissing(comm)
         total_sum = MPI.allreduce([sum(baselines)], MPI.SUM, comm)[1]
     else
         total_sum = sum(baselines)
-    end
-
-    if rank==0
-        println("The sum of baselines is: $total_sum")
     end
 
     (destr_map, baselines)
@@ -543,7 +527,7 @@ end
 
 
 @doc raw"""
-    baselines_covmat(polarimeters, σ_k, baseline_length_s, fsamp_hz, total_time) -> covariance_matrix
+    baselines_covmat(polarimeters, sigma_k, baseline_length_s, fsamp_hz, total_time) -> covariance_matrix
 
 This function produces the covariance matrix of the 1/f baselines computed by the destriper.
 As an approximation, we ignore nondiagonal terms (i.e. the correlations between different baselines).
@@ -553,39 +537,36 @@ Another assumption is that the white noise variance stays constant over a given 
 The baseline error is computed according to equation 29 in https://arxiv.org/abs/0904.3623
 
 The parameters passed to the function have the following meaning:
-    -`polarimeters`: the array of polarimeters ID numbers 
-    -`σ_k`: the array of corresponding white noise σ (in K)
+    -`polarimeters`: the array of polarimeters ID numbers
+    -`sigma_k`: the array of corresponding white noise sigma (in K)
     -`baseline_length_s` = the length (in s) of each 1/f baseline
     -`fsamp_hz` = the sampling frequency (in Hz)
     -`total_time` = the duration (in s) of the observation
 
-The function firstly computes an Array of structures `data_properties_struct`,
-which matches the white noise variance σ with the number of 1/f baselines and their lengths, for each polarimeter.
-Then it computes the covariance matrix according to these matches.     
-"""       
-function baselines_covmat(polarimeters, σ_k, baseline_length_s, fsamp_hz, total_time)
+The function firstly computes an Array of structures `TodNoiseProperties`,
+which matches the white noise variance sigma with the number of 1/f baselines and their lengths, for each polarimeter.
+Then it computes the covariance matrix according to these matches.
+"""
+function baselines_covmat(polarimeters, sigma_k, baseline_length_s, fsamp_hz, total_time)
 
-    ALL_data_properties = Array{data_properties_struct}(undef, length(polarimeters))
-    baselines_per_pol =  Int64(total_time/baseline_length_s)
+    ALL_data_properties = Array{TodNoiseProperties}(undef, length(polarimeters))
+    baselines_per_pol =  Int64(total_time / baseline_length_s)
     for i in 1:length(polarimeters)
-        baselines_lengths  = repeat([baseline_length_s*fsamp_hz], baselines_per_pol)
-        ALL_data_properties[i]  = data_properties_struct(polarimeters[i], σ_k[i], sum(baselines_lengths), baselines_per_pol, baselines_lengths)
+        baselines_lengths  = repeat([baseline_length_s * fsamp_hz], baselines_per_pol)
+        ALL_data_properties[i]  = TodNoiseProperties(polarimeters[i], sigma_k[i], sum(baselines_lengths), baselines_lengths)
     end
 
     covariance_matrix = []
-    for i in 1:length(ALL_data_properties) 
-        partial_covmat = Array{Float64}(undef,length(ALL_data_properties[i].baselines_lengths))
-        
-        for j in 1:length(ALL_data_properties[i].baselines_lengths) 
-            σ = ALL_data_properties[i].σ
-            this_baseline_length = ALL_data_properties[i].baselines_lengths[j]  
-            
-            partial_covmat[j] = σ^2/this_baseline_length    
+    for i in 1:length(ALL_data_properties)
+        partial_covmat = Array{Float64}(undef, length(ALL_data_properties[i].baselines_lengths))
+
+        for j in 1:length(ALL_data_properties[i].baselines_lengths)
+            sigma = ALL_data_properties[i].sigma
+            this_baseline_length = ALL_data_properties[i].baselines_lengths[j]
+
+            partial_covmat[j] = sigma^2 / this_baseline_length
         end
         covariance_matrix = append!(covariance_matrix, partial_covmat)
     end
     return covariance_matrix
 end
-
-
-   

--- a/test/noisegeneration_tests.jl
+++ b/test/noisegeneration_tests.jl
@@ -1,20 +1,31 @@
 using Test
 using Statistics
 
-
 baseline_length_s = 10
 fsamp_hz = 10
 fknee_hz = [0.01, 0.01]
 σ_k = [0.1, 100]
 slope = [-1,-1]
 
-
 chunks = [[datachunk(1, 1, 1000, 1000), datachunk(2, 1, 1000, 1000)]]
 baselines_per_process = 2000
-rank=0
-comm = missing
+rank = 0
+comm = nothing
 
-noise =  generate_noise_mpi(chunks, baselines_per_process, baseline_length_s, total_time, fsamp_hz, σ_k, fknee_hz, slope,rank, comm, 1234)
-@test length(noise) == fsamp_hz*baseline_length_s*baselines_per_process
-@test std(noise[1:100000]) ≈ σ_k[1]  rtol=0.01
-@test std(noise[end-100000: end]) ≈ σ_k[2]  rtol=0.01
+noise =  generate_noise_mpi(
+    chunks,
+    baselines_per_process,
+    baseline_length_s,
+    total_time,
+    fsamp_hz,
+    σ_k,
+    fknee_hz,
+    slope;
+    rank = rank,
+    comm = comm,
+    input_seed = 1234,
+)
+
+@test length(noise) == fsamp_hz * baseline_length_s*baselines_per_process
+@test std(noise[1:100000]) ≈ σ_k[1] rtol=0.01
+@test std(noise[end-100000: end]) ≈ σ_k[2] rtol=0.01


### PR DESCRIPTION
- Use `nothing` as the default to MPI communicators instead of `missing`
- Make `destripe` return a structure describing the convergence of the algorithm, instead of just the baselines and the map
- Use more keyword parameters for those parameters that can be easily defaulted
- Make sure that unique noise seeds are used for different polarimeters when generating noise timelines