### PR TITLE
Fix bug #42

### DIFF
--- a/docs/src/scanning.md
+++ b/docs/src/scanning.md
@@ -11,4 +11,7 @@ telescopetoground
 groundtoearth
 genpointings
 timetorotang
+northdir
+eastdir
+polarizationangle
 ```

--- a/src/instrumentdb.jl
+++ b/src/instrumentdb.jl
@@ -176,7 +176,11 @@ Initialize a BandshapeInfo object with all values set to zero.
 BandshapeInfo() = BandshapeInfo(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, Float64[], 0, 0)
 
 function bandshape(bandinfo::BandshapeInfo)
-    ν = range(bandinfo.lowest_frequency_hz, bandinfo.highest_frequency_hz, length = bandinfo.num_of_frequencies)
+    ν = range(
+        bandinfo.lowest_frequency_hz,
+        stop = bandinfo.highest_frequency_hz,
+        length = bandinfo.num_of_frequencies,
+    )
 
     @assert length(ν) == length(bandinfo.bandshape)
     (ν, bandinfo.bandshape, bandinfo.bandshape_error)

--- a/src/scanning.jl
+++ b/src/scanning.jl
@@ -206,9 +206,12 @@ end
     polarizationangle(northdir, eastdir, poldir)
 
 Calculate the polarization angle projected in the sky in IAU
-conventions.  The parameter `northdir` must be a versor that points
-the North and `poldir` must be a versor that identify the polarization
-direction projected in the sky.  The return value is in radians.
+conventions. The parameters `northdir` and `eastdir` must be versors
+that point towards the North and East, respectively; `poldir` must be
+a versor that identify the polarization direction projected in the
+sky. The return value is in radians, and it is zero if the
+polarization angles points toward East, π/2 if it points toward North,
+etc.
 
 # Examples
 ```jldoctest

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,11 @@
 using Test
 using Stripeline
+using Documenter
+
+@testset "Doctests" begin
+    DocMeta.setdocmeta!(Stripeline, :DocTestSetup, :(using Stripeline); recursive=true)
+    doctest(Stripeline, manual = false)
+end
 
 @testset "Instrument database" begin
     include("instrumentdb_tests.jl")


### PR DESCRIPTION
The function `polarization angle` now requires a versor pointing toward East as well as a versor pointing toward North. In this way, it can properly return polarization angles in the range [0, 360°)