### PR TITLE
Update Documenter dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,15 @@ addons:
       - gfortran
       - mpich
       - libmpich-dev
+      - libxt6
+      - libxrender1
+      - libgl1-mesa-glx
+      - libqt5widgets5
 
 jobs:
   include:
     - stage: "Documentation"
-      julia: 1.3
+      julia: 1.4
       os: linux
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/lspestrip/Stripeline.jl"))'

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -9,6 +9,12 @@ version = "0.4.0"
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
+[[BinaryProvider]]
+deps = ["Libdl", "SHA"]
+git-tree-sha1 = "5b08ed6036d9d3f0ee6369410b830f8873d4024c"
+uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+version = "0.5.8"
+
 [[Bzip2_jll]]
 deps = ["Libdl", "Pkg"]
 git-tree-sha1 = "3663bfffede2ef41358b6fc2e1d8a6d50b3c3904"
@@ -80,6 +86,12 @@ git-tree-sha1 = "814bf7865005bee373521cb49cad46182bec53b4"
 uuid = "b22a6f82-2f65-5046-a5b2-351ab43fb4e5"
 version = "4.1.0+2"
 
+[[FITSIO]]
+deps = ["BinaryProvider", "Libdl", "Printf"]
+git-tree-sha1 = "6624bd0cdd03aa82df34d3eac56ab77ff696472e"
+uuid = "525bcba6-941b-5504-bd06-fd0dc1a4d2eb"
+version = "0.14.0"
+
 [[FixedPointNumbers]]
 git-tree-sha1 = "3ba9ea634d4c8b289d590403b4a06f8e227a6238"
 uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
@@ -108,6 +120,12 @@ deps = ["ColorTypes", "FixedPointNumbers", "LinearAlgebra", "StaticArrays"]
 git-tree-sha1 = "96fd99cf83b1952a7d8cb54f4c585a648275805a"
 uuid = "4d00f742-c7ba-57c2-abde-4428a4b178cb"
 version = "0.8.2"
+
+[[Healpix]]
+deps = ["FITSIO", "Printf", "RecipesBase", "Test"]
+git-tree-sha1 = "f753b15832fc0876cd80fdec7978700ba832d05d"
+uuid = "9f4e344d-96bc-545a-84a3-ae6b9e1b672b"
+version = "2.3.0"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
 AstroLib = "c7932e45-9af1-51e7-9da9-f004cd3a462b"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Healpix = "9f4e344d-96bc-545a-84a3-ae6b9e1b672b"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,6 +8,8 @@ using Documenter, Stripeline
 
 DocMeta.setdocmeta!(Stripeline, :DocTestSetup, :(using Stripeline); recursive=true)
 
+ENV["GKSwstype"] = "100"  # Disable display of plots
+
 makedocs(
     modules = [Stripeline],
     format = Documenter.HTML(

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,8 @@ if Base.HOME_PROJECT[] !== nothing
     Base.HOME_PROJECT[] = abspath(Base.HOME_PROJECT[])
 end
 
-push!(LOAD_PATH, joinpath("..", "src"))
+library_path = joinpath("..", "src")
+(library_path in LOAD_PATH) || push!(LOAD_PATH, library_path)
 
 using Documenter, Stripeline
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,6 +6,8 @@ push!(LOAD_PATH, joinpath("..", "src"))
 
 using Documenter, Stripeline
 
+DocMeta.setdocmeta!(Stripeline, :DocTestSetup, :(using Stripeline); recursive=true)
+
 makedocs(
     modules = [Stripeline],
     format = Documenter.HTML(

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,11 +14,6 @@ ENV["GKSwstype"] = "100"  # Disable display of plots
 makedocs(
     modules = [Stripeline],
     format = Documenter.HTML(
-        assets = [
-            Documenter.asset("https://threejs.org/build/three.js"),
-            #joinpath("assets", "three.min.js"),
-            joinpath("assets", "OrbitControls.js"),
-        ],
         prettyurls = get(ENV, "CI", nothing) == "true",
     ),
     sitename = "Stripeline.jl",

--- a/docs/src/scanning.md
+++ b/docs/src/scanning.md
@@ -246,8 +246,10 @@ end
 # Save the result into an animated GIF file, with 10 frames per second.
 # As one frame in our animation lasts one minute, this means that each
 # second in the animation corresponds to 10 minutes
-gif(anim, "scanning-animation.gif", fps = 10)
+gif(anim, "scanning-animation.gif", fps = 10);
 ```
+
+![](scanning-animation.gif)
 
 Note that most of the pixels are observed a few times, but those on
 the uppermost and lowermost part of the strip have a much higher hit


### PR DESCRIPTION
There are weird error messages appearing on the documentation page of Stripeline. This PR follows the suggestion outlined here:

https://discourse.julialang.org/t/error-with-julia-1-0-plots-with-gr-and-pyplot-conda/14118/2