### PR TITLE
Ignore errors for CI builds done on Julia nightly

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -34,6 +34,7 @@ jobs:
         uses: julia-actions/julia-buildpkg@latest
       - name: "Run unit tests"
         uses: julia-actions/julia-runtest@latest
+        continue-on-error: ${{ matrix.version == 'nightly' }}
 
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: Julia ${{ matrix.julia-version }} - ${{ matrix.os }} - ${{ matrix.arch }}
-    timeout-minutes: 15
+    timeout-minutes: 25
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Since Julia nightly is always erroring tests, this PR makes GitHub ignore those errors. See https://discourse.julialang.org/t/ci-broken-on-nightly/78159/3
