### PR TITLE
Bump codecov action from v1 (deprecated) to v2

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -37,6 +37,6 @@ jobs:
         continue-on-error: ${{ matrix.version == 'nightly' }}
 
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         with:
           file: lcov.info


### PR DESCRIPTION
As described in https://about.codecov.io/blog/introducing-codecovs-new-uploader/, codecov has switched to another uploader and thus the old GitHub action is no longer supported. This PR bumps it to version 2.
