### PR TITLE
Fix issue #56

### DIFF
--- a/src/scanning.jl
+++ b/src/scanning.jl
@@ -310,6 +310,7 @@ function genpointings!(wheelanglesfn,
         groundq = telescopetoground(wheelanglesfn, time_s)
         # This converts the MCS into the celestial reference frame
         quat = groundtoearth(groundq, time_s, latitude_deg; day_duration_s = day_duration_s)
+            
         θ, ϕ, curpsi = quat_to_angles(beam_dir, polaxis, quat)
         (dirs[idx, 1], dirs[idx, 2]) = (θ, ϕ)
 
@@ -395,7 +396,7 @@ function genpointings!(wheelanglesfn,
         north = northdir(π / 2 - Dec_rad, Ra_rad)
         east = eastdir(π / 2 - Dec_rad, Ra_rad)
 
-        skydirs[idx, 1] = Dec_rad
+        skydirs[idx, 1] = π/2 - Dec_rad
         skydirs[idx, 2] = Ra_rad
         skypsi[idx] = polarizationangle(north, east, poldir)
     end

--- a/test/scanning.jl
+++ b/test/scanning.jl
@@ -42,8 +42,8 @@ dir = inv(rotmatr) * vector
                                nutation = true,
                                aberration = true,
                                refraction = true)
-crab_position_skydirs = sqrt(skydirs[1]^2 + skydirs[2]^2)
-@test skydirs[1] ≈ crab_dec_astropy_rad atol = eps
+crab_position_skydirs = sqrt((π/2 - skydirs[1])^2 + skydirs[2]^2)
+@test skydirs[1] ≈ π/2 - crab_dec_astropy_rad atol = eps
 @test skydirs[2] ≈ crab_ra_astropy_rad atol = eps
 @test crab_position_skydirs ≈ crab_position atol = eps
 
@@ -101,13 +101,13 @@ for (idx, day) in enumerate(days)
     skydirs[idx, 2] = skydirections[2]
 end
 
-crab_position_skydirs = sqrt.(skydirs[:, 1].^2 + skydirs[:, 2].^2)
+crab_position_skydirs = sqrt.((π/2 .- skydirs[:, 1]).^2 + skydirs[:, 2].^2)
 
-@test skydirs[1, 1] ≈ crab_dec_astropy_rad atol = eps
+@test skydirs[1, 1] ≈ π/2 - crab_dec_astropy_rad atol = eps
 @test skydirs[1, 2] ≈ crab_ra_astropy_rad atol = eps
-@test skydirs[2, 1] ≈ crab_dec_astropy_rad atol = eps
+@test skydirs[2, 1] ≈ π/2 - crab_dec_astropy_rad atol = eps
 @test skydirs[2, 2] ≈ crab_ra_astropy_rad atol = eps
-@test skydirs[3, 1] ≈ crab_dec_astropy_rad atol = eps
+@test skydirs[3, 1] ≈ π/2 - crab_dec_astropy_rad atol = eps
 @test skydirs[3, 2] ≈ crab_ra_astropy_rad atol = eps
 @test crab_position_skydirs[1] ≈ crab_position atol = eps
 @test crab_position_skydirs[2] ≈ crab_position atol = eps


### PR DESCRIPTION
The code wrongly assumed that in Equatorial coordinates the declination can be interpreted as a colatitude. It's not, it's a *latitude*! This PR inserts some crucial π/2 factors in the code for `genpointings` and in the tests to fix the inconsistency.
