### PR TITLE
Bump the minimum supported version of Julia to 1.6

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -11,11 +11,11 @@ on:
 jobs:
   test:
     name: Julia ${{ matrix.julia-version }} - ${{ matrix.os }} - ${{ matrix.arch }}
-    timeout-minutes: 25
+    timeout-minutes: 10
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ['1.3', '1']
+        julia-version: ['1.6', '1']
         os: [ubuntu-latest, windows-latest, macOS-latest]
         arch:
           - x64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # HEAD
 
+-   Bump the requirement on the minimum Julia version from 1.3 to 1.6 [#64](https://github.com/lspestrip/Stripeline.jl/pull/64)
 -   Prevent crashes in the destriper [#63](https://github.com/lspestrip/Stripeline.jl/pull/63)
 -   Implement the pointing reconstruction model [#55](https://github.com/lspestrip/Stripeline.jl/pull/55)
 -   Fix dependency on Documenter.jl [#59](https://github.com/lspestrip/Stripeline.jl/pull/59), [#60](https://github.com/lspestrip/Stripeline.jl/pull/60)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ strategy of the telecope and the response of the detectors, up to the creation
 of frequency maps.
 
 Stripeline is written in [Julia](https://julialang.org). The current version
-requires Julia 1.3 or higher.
+requires Julia 1.6 or higher.
 
 ## Installation and usage
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+# How to tag a new release
+
+-   Bump the version number in `Project.toml`
+-   Run `Pkg.update()`
+-   Add a comment to the commit where you bumped the version number: `@JuliaRegistrator register`
+


### PR DESCRIPTION
This PR bumps the minimum version of Julia used to run the tests from 1.3 to 1.6.
